### PR TITLE
fix: address issues #5 #6 #7 #8 — platform compat, severity, install UX

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -87,7 +87,10 @@ fi
 echo "[1/5] Building GoPlus AgentGuard..."
 if [ -f "$SCRIPT_DIR/package.json" ]; then
   cd "$SCRIPT_DIR"
-  npm install --ignore-scripts 2>/dev/null
+  if ! npm install --ignore-scripts 2>&1 | tail -3; then
+    echo "  WARN: npm install failed. Some features may not work."
+    echo "  Try running manually: cd $SCRIPT_DIR && npm install"
+  fi
   npm run build 2>/dev/null
   echo "  OK: Build complete"
 else
@@ -99,7 +102,10 @@ fi
 echo "[2/5] Installing CLI dependencies..."
 if [ -d "$SKILL_SRC/scripts" ]; then
   cd "$SKILL_SRC/scripts"
-  npm install 2>/dev/null
+  if ! npm install 2>&1 | tail -3; then
+    echo "  WARN: CLI dependency install failed."
+    echo "  Try running manually: cd $SKILL_SRC/scripts && npm install"
+  fi
   echo "  OK: CLI dependencies installed"
 fi
 
@@ -129,7 +135,10 @@ fi
 # Install node_modules in the target (avoids symlink issues in containers)
 cd "$SKILLS_DIR/scripts"
 if [ -f "package.json" ]; then
-  npm install 2>/dev/null
+  if ! npm install 2>&1 | tail -3; then
+    echo "  WARN: Script dependency install failed in target."
+    echo "  Try running manually: cd $SKILLS_DIR/scripts && npm install"
+  fi
   echo "  OK: Scripts and dependencies installed"
 else
   echo "  WARN: No package.json found in scripts directory"
@@ -143,6 +152,15 @@ if [ ! -f "$AGENTGUARD_DIR/config.json" ]; then
   echo "  OK: Config created (protection level: balanced)"
 else
   echo "  OK: Config already exists (keeping current settings)"
+fi
+
+# ---- Verify scripts ----
+if [ -f "$SKILLS_DIR/scripts/checkup-report.js" ]; then
+  if ! node --check "$SKILLS_DIR/scripts/checkup-report.js" 2>/dev/null; then
+    echo ""
+    echo "  WARN: checkup-report.js has missing dependencies."
+    echo "  Run: cd $SKILLS_DIR/scripts && npm install"
+  fi
 fi
 
 # ---- Done ----
@@ -173,9 +191,12 @@ echo "  Installed to: $SKILLS_DIR"
 echo "  Platform:     $PLATFORM"
 echo ""
 echo "  Other commands:"
-echo "    /agentguard scan <path>    Scan code for security risks"
-echo "    /agentguard trust list     View trusted skills"
-echo "    /agentguard report         View security event log"
+echo "    /agentguard scan <path>       Scan code for security risks"
+echo "    /agentguard action <desc>     Evaluate action safety"
+echo "    /agentguard trust list        View trusted skills"
+echo "    /agentguard report            View security event log"
+echo "    /agentguard config <level>    Set protection level"
+echo "    /agentguard patrol            Security patrol (OpenClaw)"
 echo ""
 echo "  To uninstall: ./setup.sh --uninstall"
 echo ""

--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -89,7 +89,7 @@ For each rule, use Grep to search the relevant file types. Record every match wi
 | 21 | TROJAN_DISTRIBUTION | CRITICAL | md | Trojanized binary download + password + execute |
 | 22 | SUSPICIOUS_PASTE_URL | HIGH | all | URLs to paste sites (pastebin, glot.io, etc.) |
 | 23 | SUSPICIOUS_IP | MEDIUM | all | Hardcoded public IPv4 addresses |
-| 24 | SOCIAL_ENGINEERING | MEDIUM | md | Pressure language + execution instructions |
+| 24 | SOCIAL_ENGINEERING | HIGH | md | Pressure language + execution instructions |
 
 ### Risk Level Calculation
 
@@ -265,6 +265,17 @@ For non-OpenClaw environments, use /agentguard scan and /agentguard report inste
 
 Set `$OC` to the resolved OpenClaw state directory for all subsequent checks.
 
+### Platform Detection
+
+Before running checks, detect the operating system to select the appropriate command variants:
+
+1. Run `uname -s` to get the OS kernel name
+2. Use platform-specific commands throughout:
+   - **Darwin** (macOS): `lsof`, `stat -f "%Lp"`, `/usr/libexec/ApplicationFirewall/socketfilterfw`, `launchctl`
+   - **Linux**: `ss`, `stat -c "%a"`, `ufw`/`iptables`, `systemctl`
+3. For portable permission checks, try both: `stat -f '%Lp' <path> 2>/dev/null || stat -c '%a' <path> 2>/dev/null`
+4. For finding executables, use: `find <path> -type f -executable -mtime -1 2>/dev/null || find <path> -type f -perm +111 -mtime -1 2>/dev/null`
+
 ### The 8 Patrol Checks
 
 #### [1] Skill/Plugin Integrity
@@ -324,7 +335,7 @@ Detect suspicious file modifications in the last 24 hours.
    - `$OC/openclaw.json` → should be 600
    - `$OC/devices/paired.json` → should be 600
    - `~/.ssh/authorized_keys` → should be 600
-4. Detect new executable files in workspace: `find $OC/workspace/ -type f -perm +111 -mtime -1`
+4. Detect new executable files in workspace: `find $OC/workspace/ -type f -executable -mtime -1 2>/dev/null || find $OC/workspace/ -type f -perm +111 -mtime -1 2>/dev/null`
 
 #### [6] Audit Log Analysis (24h)
 

--- a/skills/agentguard/patrol-checks.md
+++ b/skills/agentguard/patrol-checks.md
@@ -139,7 +139,10 @@ iptables -L INPUT -n 2>/dev/null | head -20
 
 ```bash
 # Established outbound connections
+# Linux
 ss -tnp state established 2>/dev/null || netstat -tnp 2>/dev/null | grep ESTABLISHED
+# macOS
+lsof -i -P -n 2>/dev/null | grep ESTABLISHED
 ```
 
 Cross-reference remote IPs/domains against:
@@ -165,10 +168,13 @@ crontab -l 2>/dev/null
 # System cron directories
 ls -la /etc/cron.d/ /etc/cron.daily/ /etc/cron.hourly/ 2>/dev/null
 
-# Systemd timers
+# Systemd timers (Linux only — skip on macOS)
 systemctl list-timers --all 2>/dev/null
 
-# User systemd units
+# macOS launch agents
+launchctl list 2>/dev/null
+
+# User systemd units (Linux only)
 ls -la ~/.config/systemd/user/ 2>/dev/null
 ```
 
@@ -226,7 +232,7 @@ find /etc/cron.d/ -type f -mtime -1 2>/dev/null
 
 4. **New executable detection**:
    ```bash
-   find $OC/workspace/ -type f -perm +111 -mtime -1 2>/dev/null
+   find $OC/workspace/ -type f -executable -mtime -1 2>/dev/null || find $OC/workspace/ -type f -perm +111 -mtime -1 2>/dev/null
    ```
 
 ---

--- a/skills/agentguard/scan-rules.md
+++ b/skills/agentguard/scan-rules.md
@@ -292,7 +292,7 @@ Detects trojanized binary distribution patterns. Flags when 2+ of the following 
 - Version-like patterns (`x.0.0.0`)
 - Values > 255 in any octet
 
-## Rule 24: SOCIAL_ENGINEERING (MEDIUM)
+## Rule 24: SOCIAL_ENGINEERING (HIGH)
 **Files**: `*.md`
 
 | Pattern | Description |

--- a/src/scanner/rules/trojan.ts
+++ b/src/scanner/rules/trojan.ts
@@ -72,7 +72,7 @@ export const TROJAN_RULES: ScanRule[] = [
   {
     id: 'SOCIAL_ENGINEERING',
     description: 'Detects social engineering pressure language in skill instructions',
-    severity: 'medium',
+    severity: 'high',
     file_patterns: ['*.md'],
     patterns: [
       /CRITICAL\s+REQUIREMENT/i,


### PR DESCRIPTION
## Summary

- **#6** Upgrade `SOCIAL_ENGINEERING` rule severity from MEDIUM → HIGH (pressure language + command execution is a direct attack vector)
- **#7** Add missing `action`, `config`, `patrol` commands to post-install message in `setup.sh`
- **#8** Surface `npm install` errors instead of silently redirecting to `/dev/null`; add script verification step before "Done" to catch missing dependencies early
- **#5** Add platform detection section to patrol; fix BSD-only `find -perm +111` with portable fallback; add macOS alternatives for outbound connections and launch agents

## Files changed

| File | Changes |
|------|---------|
| `src/scanner/rules/trojan.ts` | SOCIAL_ENGINEERING severity `medium` → `high` |
| `skills/agentguard/scan-rules.md` | Rule 24 heading MEDIUM → HIGH |
| `skills/agentguard/SKILL.md` | Detection table severity + patrol platform detection |
| `skills/agentguard/patrol-checks.md` | Cross-platform command fallbacks |
| `setup.sh` | Post-install commands + npm error handling + script verification |

## Test plan

- [ ] Run `npm run build` — should succeed
- [ ] Verify `SOCIAL_ENGINEERING` severity is `high` in source and docs
- [ ] Run `./setup.sh` — confirm all 6 subcommands shown in post-install output
- [ ] Simulate npm install failure — confirm warning is printed instead of silent swallow
- [ ] Review patrol section in SKILL.md for cross-platform command coverage

Closes #5, Closes #6, Closes #7, Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)