### PR TITLE
fix: guard against undefined text in recommendations causing toLowerC…

### DIFF
--- a/skills/agentguard/scripts/checkup-report.js
+++ b/skills/agentguard/scripts/checkup-report.js
@@ -746,7 +746,8 @@ function generateReport(data) {
     autoRecs.push({ severity: 'LOW', text: 'Enable auto-scan on session start: export AGENTGUARD_AUTO_SCAN=1', zh: '启用会话启动时自动扫描：export AGENTGUARD_AUTO_SCAN=1' });
 
   // Merge: user recs first, then auto recs (dedup by text similarity)
-  const allRecs = [...recommendations];
+  // Guard against malformed entries where text may be undefined (#37)
+  const allRecs = recommendations.filter(r => r && typeof r.text === 'string');
   for (const ar of autoRecs) {
     if (!allRecs.some(r => r.text.toLowerCase().includes(ar.text.slice(0, 30).toLowerCase()))) {
       allRecs.push(ar);


### PR DESCRIPTION
…ase crash (#37)

If a recommendation object is missing the text field (e.g. Claude only emitted a zh field or passed a malformed entry), r.text.toLowerCase() throws "Cannot read properties of undefined (reading 'toLowerCase')".

Filter recommendations to only include entries with a valid string text field before the dedup/merge loop.

## Summary

Brief description of the changes.

## Type

- [✅ ] Bug fix
- [ ] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [ ] `npm run build` passes
- [ ] `npm test` passes (32 tests)
- [ ] Manually tested the change

## Related Issues

Closes #37
