### PR TITLE
fix: read CLI version from package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.3] - 2026-05-12
+
+### Fixed
+- Read the CLI `--version` value from `package.json` so published package and binary versions stay in sync.
+
 ## [1.1.2] - 2026-05-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@goplus/agentguard",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goplus/agentguard",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goplus/agentguard",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "GoPlus AgentGuard — Security guard for AI agents. Blocks dangerous commands, prevents data leaks, protects secrets. 20 detection rules, runtime action evaluation, trust registry.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { Command } from 'commander';
 import { AgentGuardCloudClient } from './cloud/client.js';
 import {
@@ -24,7 +25,7 @@ async function main() {
   program
     .name('agentguard')
     .description('Local-first security guard for AI agents, with optional AgentGuard Cloud control plane')
-    .version('1.1.1');
+    .version(readPackageVersion());
 
   program
     .command('init')
@@ -172,6 +173,11 @@ function readStdinIfAvailable(): string {
   } catch {
     return '';
   }
+}
+
+function readPackageVersion(): string {
+  const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8')) as { version?: string };
+  return packageJson.version || '0.0.0';
 }
 
 main().catch((error) => {

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const projectRoot = resolve(__dirname, '..', '..');
+const cliPath = join(projectRoot, 'dist', 'cli.js');
+const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8')) as { version: string };
+
+function runCli(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolvePromise) => {
+    const child = spawn('node', [cliPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data: Buffer) => (stdout += data.toString()));
+    child.stderr.on('data', (data: Buffer) => (stderr += data.toString()));
+    child.on('close', (code) => {
+      resolvePromise({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+describe('AgentGuard CLI', () => {
+  it('prints the package version for --version', async () => {
+    const result = await runCli(['--version']);
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.equal(result.stdout.trim(), packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary
- bump @goplus/agentguard to 1.1.3
- read agentguard --version from package.json instead of a hard-coded string
- add CLI coverage so package.json and binary version stay aligned

## Verification
- npm run build
- node --test dist/tests/cli.test.js
- npm test