### PR TITLE
fix: allow ordinary OpenClaw exec commands

### DIFF
--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -56,7 +56,9 @@ export class ActionScanner {
 
     // Look up skill capabilities
     const lookupResult = await this.registry.lookup(actor.skill);
-    const capabilities = lookupResult.effective_capabilities;
+    const capabilities = lookupResult.record === null
+      ? this.defaultCapabilities
+      : lookupResult.effective_capabilities;
     const trustLevel = lookupResult.effective_trust_level;
 
     // Route to appropriate handler based on action type

--- a/src/adapters/openclaw-plugin.ts
+++ b/src/adapters/openclaw-plugin.ts
@@ -341,11 +341,13 @@ export function registerOpenClawPlugin(
   // Lazy-initialize agentguard instance
   let agentguard: AgentGuardInstance | null = null;
 
-  // Build default capabilities from workspacePaths so the core session
-  // can access its own workspace files without a manual registry entry.
-  const defaultCapabilities = options.workspacePaths
-    ? { ...DEFAULT_CAPABILITY, filesystem_allowlist: options.workspacePaths }
-    : undefined;
+  // Build default capabilities so the core OpenClaw session can run normal
+  // commands and access its workspace without a manual registry entry.
+  const defaultCapabilities = {
+    ...DEFAULT_CAPABILITY,
+    exec: 'allow' as const,
+    ...(options.workspacePaths ? { filesystem_allowlist: options.workspacePaths } : {}),
+  };
 
   function getAgentGuard(): AgentGuardInstance {
     if (!agentguard) {
@@ -355,7 +357,7 @@ export function registerOpenClawPlugin(
         // Build inline — avoids require() and passes workspace defaults
         const actionScanner = new ActionScanner({
           registry: trustRegistry,
-          ...(defaultCapabilities ? { defaultCapabilities } : {}),
+          defaultCapabilities,
         });
         agentguard = {
           registry: trustRegistry as unknown as AgentGuardInstance['registry'],

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -135,6 +135,21 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
     assert.equal(result, undefined, 'Safe command should be allowed');
   });
 
+  it('should allow non-whitelisted ordinary exec commands by default', async () => {
+    ctx = createTestContext();
+    const { api, handlers } = createMockApi();
+    registerOpenClawPlugin(api as never, {
+      skipAutoScan: true,
+      registry: ctx.agentguard.registry as never,
+    });
+
+    const result = await handlers['before_tool_call']({
+      toolName: 'exec',
+      params: { command: 'agentguard status' },
+    });
+    assert.equal(result, undefined, 'Ordinary OpenClaw exec command should be allowed');
+  });
+
   it('should return { block: true } for rm -rf /', async () => {
     ctx = createTestContext();
     const { api, handlers } = createMockApi();


### PR DESCRIPTION
## Summary

Fixes #65.

This PR fixes the OpenClaw plugin default exec behavior so ordinary non-whitelisted commands such as `agentguard status` are not blocked by default.

## Changes

- Make `ActionScanner.defaultCapabilities` take effect when no registry record exists.
- Set OpenClaw core session default capabilities to allow exec commands.
- Preserve existing `workspacePaths` default filesystem allowlist behavior.
- Add an OpenClaw integration regression test for non-whitelisted ordinary exec commands.

## Verification

- `npm run build`
- `npm test`  
  - 170 passed, 0 failed
- `git diff --check`


## Type

- [ ] Bug fix
- [ ] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [ ] `npm run build` passes
- [ ] `npm test` passes (32 tests)
- [ ] Manually tested the change

## Related Issues

Closes #
