### PR TITLE
fix: enable OpenClaw plugin during AgentGuard install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## [1.1.6] - 2026-05-18
+## [1.1.7] - 2026-05-18
 
 ### Fixed
 - Added the missing `agentguard policy pull` command used by AgentGuard Cloud policy refresh instructions.
+- OpenClaw installs now enable the AgentGuard plugin when installing the skill through `setup.sh` or running `agentguard init --agent openclaw`.
+- Added a dedicated OpenClaw package entry so OpenClaw loads the runtime plugin instead of the generic SDK entrypoint.
 
 ## [1.1.5] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ agentguard subscribe --json
 # Or run a one-off self-check against a single advisory id
 agentguard checkup --against-advisory AGS-2026-0042
 
-# Optional: write host-specific hook templates
+# Optional: write host-specific hook templates.
+# OpenClaw also installs and enables the AgentGuard plugin.
 agentguard init --agent claude-code
 agentguard init --agent codex
 agentguard init --agent openclaw
@@ -135,7 +136,13 @@ cp -r agentguard/skills/agentguard ~/.claude/skills/agentguard
 npm install @goplus/agentguard
 ```
 
-Register in your OpenClaw plugin config:
+Then enable it:
+
+```bash
+agentguard init --agent openclaw
+```
+
+Or register manually in your OpenClaw plugin config:
 
 ```typescript
 import register from '@goplus/agentguard/openclaw';

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -4,13 +4,13 @@ OpenClaw can use AgentGuard as a local runtime guard and optional Cloud-connecte
 
 ## Plugin usage
 
-To write a starter plugin file in the current project:
+To install and enable the AgentGuard OpenClaw plugin:
 
 ```bash
 agentguard init --agent openclaw
 ```
 
-This creates `openclaw.agentguard.plugin.ts`.
+This creates a local plugin under `~/.openclaw/plugins/agentguard` and enables it in `~/.openclaw/openclaw.json`.
 
 ```ts
 import { registerOpenClawPlugin } from '@goplus/agentguard';

--- a/openclaw.d.ts
+++ b/openclaw.d.ts
@@ -1,0 +1,6 @@
+export { default } from './dist/openclaw.js';
+export {
+  getPluginIdFromTool,
+  getPluginScanResult,
+  registerOpenClawPlugin,
+} from './dist/openclaw.js';

--- a/openclaw.js
+++ b/openclaw.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/openclaw.js');

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "agentguard",
   "name": "GoPlus AgentGuard",
   "description": "AI agent security framework — blocks dangerous commands, prevents data leaks, and protects secrets",
+  "skills": ["./skills"],
   "configSchema": {
     "type": "object",
     "properties": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "openclaw": {
     "extensions": [
-      "./dist/index.js"
+      "./dist/openclaw.js"
     ]
   },
   "bin": {
@@ -66,6 +66,8 @@
     "examples/openclaw-docker",
     "README.md",
     "LICENSE",
+    "openclaw.d.ts",
+    "openclaw.js",
     "openclaw.plugin.json",
     "skills"
   ]

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_SRC="$SCRIPT_DIR/skills/agentguard"
 AGENTGUARD_DIR="$HOME/.agentguard"
 MIN_NODE_VERSION=18
+OPENCLAW_ROOT="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+OPENCLAW_PLUGIN_DIR="$OPENCLAW_ROOT/plugins/agentguard"
+OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-$OPENCLAW_ROOT/openclaw.json}"
 
 echo ""
 echo "  GoPlus AgentGuard — AI Agent Security Guard"
@@ -76,6 +79,7 @@ if [ "${1:-}" = "--uninstall" ] || [ "${1:-}" = "uninstall" ]; then
   rm -rf "$HOME/.claude/skills/agentguard" 2>/dev/null || true
   rm -rf "$HOME/.openclaw/skills/agentguard" 2>/dev/null || true
   rm -rf "$HOME/.openclaw/workspace/skills/agentguard" 2>/dev/null || true
+  rm -rf "$OPENCLAW_PLUGIN_DIR" 2>/dev/null || true
   rm -rf "$AGENTGUARD_DIR" 2>/dev/null && echo "  Removed config from $AGENTGUARD_DIR" || true
   echo ""
   echo "  GoPlus AgentGuard has been uninstalled."
@@ -143,6 +147,76 @@ if [ ! -f "$AGENTGUARD_DIR/config.json" ]; then
   echo "  OK: Config created (protection level: balanced)"
 else
   echo "  OK: Config already exists (keeping current settings)"
+fi
+
+if [ "$PLATFORM" = "openclaw-workspace" ] || [ "$PLATFORM" = "openclaw-managed" ]; then
+  echo "  Enabling OpenClaw plugin..."
+  mkdir -p "$OPENCLAW_PLUGIN_DIR"
+  AGENTGUARD_DIST_INDEX="$SCRIPT_DIR/dist/index.js" node - "$OPENCLAW_PLUGIN_DIR/index.js" <<'NODE'
+const { writeFileSync } = require('node:fs');
+const pluginPath = process.argv[2];
+const distIndex = process.env.AGENTGUARD_DIST_INDEX;
+writeFileSync(pluginPath, `const { registerOpenClawPlugin } = require(${JSON.stringify(distIndex)});
+
+module.exports = function setup(api) {
+  registerOpenClawPlugin(api, {
+    skipAutoScan: false,
+  });
+};
+module.exports.default = module.exports;
+`);
+NODE
+  cat > "$OPENCLAW_PLUGIN_DIR/openclaw.plugin.json" <<'JSON'
+{
+  "id": "agentguard",
+  "name": "GoPlus AgentGuard",
+  "description": "AI agent security framework — blocks dangerous commands, prevents data leaks, and protects secrets",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "level": {
+        "type": "string",
+        "enum": ["strict", "balanced", "permissive"],
+        "default": "balanced",
+        "description": "Protection level: strict (block all risky), balanced (block dangerous, confirm risky), permissive (only block critical)"
+      }
+    }
+  }
+}
+JSON
+  node - "$OPENCLAW_CONFIG_PATH" "$OPENCLAW_PLUGIN_DIR" <<'NODE'
+const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('node:fs');
+const { dirname } = require('node:path');
+const [configPath, pluginDir] = process.argv.slice(2);
+const ensureRecord = (parent, key) => {
+  const existing = parent[key];
+  if (existing && typeof existing === 'object' && !Array.isArray(existing)) return existing;
+  const next = {};
+  parent[key] = next;
+  return next;
+};
+let config = {};
+if (existsSync(configPath)) {
+  const raw = readFileSync(configPath, 'utf8').trim();
+  config = raw ? JSON.parse(raw) : {};
+}
+const plugins = ensureRecord(config, 'plugins');
+const load = ensureRecord(plugins, 'load');
+const entries = ensureRecord(plugins, 'entries');
+const agentguard = ensureRecord(entries, 'agentguard');
+agentguard.enabled = true;
+const paths = Array.isArray(load.paths) ? load.paths.filter((p) => typeof p === 'string') : [];
+if (!paths.includes(pluginDir)) paths.push(pluginDir);
+load.paths = paths;
+if (Array.isArray(plugins.allow)) {
+  const allow = plugins.allow.filter((id) => typeof id === 'string');
+  if (!allow.includes('agentguard')) allow.push('agentguard');
+  plugins.allow = allow;
+}
+mkdirSync(dirname(configPath), { recursive: true });
+writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+NODE
+  echo "  OK: OpenClaw plugin enabled in $OPENCLAW_CONFIG_PATH"
 fi
 
 # ---- Done ----

--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -31,7 +31,7 @@ filesystem-access:
     reason: "Read/write audit log (audit.jsonl) and protection level config (config.json)"
 user-invocable: true
 allowed-tools: Read, Write, Grep, Glob, Bash(node *trust-cli.ts *) Bash(node *action-cli.ts *) Bash(*checkup-report.js) Bash(echo *checkup-report.js) Bash(cat *checkup-report.js) Bash(agentguard *) Bash(openclaw *) Bash(ss *) Bash(lsof *) Bash(ufw *) Bash(iptables *) Bash(crontab *) Bash(systemctl list-timers *) Bash(find *) Bash(stat *) Bash(env) Bash(sha256sum *) Bash(node *) Bash(cd *)
-argument-hint: "[scan|action|patrol|subscribe|trust|report|config|checkup] [args...]"
+argument-hint: "[scan|action|patrol|subscribe|trust|report|config|checkup|cli] [args...]"
 ---
 
 # GoPlus AgentGuard — AI Agent Security Framework
@@ -64,8 +64,31 @@ Parse `$ARGUMENTS` to determine the subcommand:
 - **`config <strict|balanced|permissive>`** — Set protection level
 - **`checkup`** — Run a comprehensive agent health checkup and generate a visual HTML report
 - **`hermes-hooks`** — Show or install Hermes shell-hook configuration for runtime protection
+- **`cli <args...>`** — Run the installed `agentguard` CLI directly for supported commands not otherwise routed by this skill
 
 If no subcommand is given, or the first argument is a path, default to **scan**.
+
+### CLI Passthrough
+
+This skill is allowed to run `agentguard *`, so CLI commands and flags are available even when the skill has a higher-level workflow for the same area.
+
+Use CLI passthrough when the user explicitly asks for a concrete `agentguard ...` command, when the command is one of the CLI-only commands below, or when a CLI flag changes semantics that this skill's high-level workflow does not implement.
+
+Supported CLI commands and options:
+
+| CLI command | Options | Notes |
+|---|---|---|
+| `agentguard init` | `--level <level>`, `--agent <agent>`, `--cloud <url>`, `--force` | Creates local config and optionally installs agent templates |
+| `agentguard connect` | `--key <key>`, `--api-key <key>`, `--url <url>`, `--cloud <url>` | Prefer `AGENTGUARD_API_KEY` over passing secrets in flags |
+| `agentguard status` | none | Shows local config, Cloud URL/API key status, policy cache, audit path |
+| `agentguard policy pull` | `--json` | Pulls Cloud effective runtime policy into the local cache |
+| `agentguard doctor` | none | Checks local setup and Cloud reachability when connected |
+| `agentguard scan <path>` | `--json` | Runs the packaged scanner against a local path |
+| `agentguard protect` | `--agent <agent>`, `--action-type <type>`, `--tool-name <name>`, `--session-id <id>`, `--decision-mode <local-first|cloud>`, `--json` | Evaluates one runtime action from stdin or hook environment |
+| `agentguard subscribe` | `--since <iso>`, `--json`, `--no-report`, `--install-cron`, `--cron-name <name>`, `--interval-minutes <minutes>`, `--force`, `--cron-run` | Pulls Cloud threat advisories and self-checks local skills |
+| `agentguard checkup` | `--against-advisory <id>`, `--json` | CLI threat-feed self-check; without `--against-advisory`, it only prints a tip in the current CLI build |
+
+If the user writes `/agentguard cli <args...>`, execute `agentguard <args...>` directly. If the user writes `/agentguard checkup --against-advisory <id>`, use the CLI command `agentguard checkup --against-advisory <id>` instead of the comprehensive HTML health-report workflow.
 
 ## Subcommand: hermes-hooks
 
@@ -152,14 +175,19 @@ Examples:
 ```bash
 agentguard subscribe
 agentguard subscribe --json
+agentguard subscribe --since 2026-05-01T00:00:00.000Z
+agentguard subscribe --no-report
 agentguard subscribe --install-cron
+agentguard subscribe --install-cron --cron-name agentguard-threat-feed
 agentguard subscribe --install-cron --interval-minutes 5
 agentguard subscribe --install-cron --force
 ```
 
-When `--install-cron` is used, the CLI registers an OpenClaw isolated cron job through the local OpenClaw Gateway at `127.0.0.1:18789`. It runs every 15 minutes by default. Pass `--interval-minutes <n>` to override the cadence. If a job with the same name already exists, the CLI leaves it untouched unless `--force` is passed. The cron delivery is intentionally silent (`delivery.mode = "none"`); the isolated turn executes `agentguard subscribe --json --cron-run` and only sends the configured notification when `shouldNotify` is `true`.
+When `--install-cron` is used, the CLI registers an OpenClaw isolated cron job through the local OpenClaw Gateway at `127.0.0.1:18789`. It runs every 15 minutes by default. Pass `--interval-minutes <n>` to override the cadence and `--cron-name <name>` to choose the job name. If a job with the same name already exists, the CLI leaves it untouched unless `--force` is passed. The cron delivery is intentionally silent (`delivery.mode = "none"`); the isolated turn executes `agentguard subscribe --json --cron-run` and only sends the configured notification when `shouldNotify` is `true`.
 
 `agentguard subscribe --json` always includes a stable `cron` object with `requested`, `installed`, and optional `result` fields. If cron installation fails, the command exits non-zero instead of printing a misleading success summary.
+
+`--since <iso>` overrides the persisted feed cursor for one run. `--no-report` skips uploading local matches back to Cloud. `--cron-run` is internal and should only be used by the OpenClaw cron prompt unless the user explicitly asks to reproduce cron behavior.
 
 ---
 
@@ -725,6 +753,15 @@ If the log file doesn't exist, inform the user that no security events have been
 ## Subcommand: checkup
 
 Run a comprehensive agent health checkup across 6 security dimensions. Generates a visual HTML report with a lobster mascot and opens it in the browser. The lobster's appearance reflects the agent's health: muscular bodybuilder (score 90+), healthy with shield (70–89), tired with coffee (50–69), or sick with bandages (0–49).
+
+If the arguments include `--against-advisory <id>`, do not run this comprehensive HTML workflow. Instead execute the CLI threat-feed self-check:
+
+```bash
+agentguard checkup --against-advisory <id>
+agentguard checkup --against-advisory <id> --json
+```
+
+That CLI path fetches the current Cloud advisory feed and checks local skills against the single advisory. It is separate from the full health report below.
 
 ### Step 1: Data Collection
 

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 export type AgentInstaller = 'claude-code' | 'codex' | 'openclaw';
@@ -12,7 +13,7 @@ export function installAgentTemplates(agent: AgentInstaller, options: { cwd?: st
   const root = options.cwd || process.cwd();
   if (agent === 'claude-code') return installClaudeCode(root, Boolean(options.force));
   if (agent === 'codex') return installCodex(root, Boolean(options.force));
-  if (agent === 'openclaw') return installOpenClaw(root, Boolean(options.force));
+  if (agent === 'openclaw') return installOpenClaw(options.cwd, Boolean(options.force));
   throw new Error(`Unsupported agent installer: ${agent}`);
 }
 
@@ -36,10 +37,22 @@ function installCodex(root: string, force: boolean): InstallResult {
   return { agent: 'codex', files: [skillPath, hookPath] };
 }
 
-function installOpenClaw(root: string, force: boolean): InstallResult {
-  const pluginPath = join(root, 'openclaw.agentguard.plugin.ts');
+function installOpenClaw(cwd: string | undefined, force: boolean): InstallResult {
+  const openClawRoot = cwd
+    ? join(cwd, '.openclaw')
+    : process.env.OPENCLAW_STATE_DIR || join(homedir(), '.openclaw');
+  const pluginDir = join(openClawRoot, 'plugins', 'agentguard');
+  const pluginPath = join(pluginDir, 'index.ts');
+  const manifestPath = join(pluginDir, 'openclaw.plugin.json');
+  const configPath = cwd
+    ? join(openClawRoot, 'openclaw.json')
+    : process.env.OPENCLAW_CONFIG_PATH || join(openClawRoot, 'openclaw.json');
+
   writeIfAllowed(pluginPath, openClawPluginTemplate(), force);
-  return { agent: 'openclaw', files: [pluginPath] };
+  writeIfAllowed(manifestPath, JSON.stringify(openClawPluginManifest(), null, 2) + '\n', force);
+  enableOpenClawPlugin(configPath, pluginDir);
+
+  return { agent: 'openclaw', files: [pluginPath, manifestPath, configPath] };
 }
 
 function writeIfAllowed(path: string, content: string, force: boolean): void {
@@ -146,4 +159,64 @@ export default function setup(api) {
   });
 }
 `;
+}
+
+function openClawPluginManifest(): unknown {
+  return {
+    id: 'agentguard',
+    name: 'GoPlus AgentGuard',
+    description: 'AI agent security framework - blocks dangerous commands, prevents data leaks, and protects secrets',
+    configSchema: {
+      type: 'object',
+      properties: {
+        level: {
+          type: 'string',
+          enum: ['strict', 'balanced', 'permissive'],
+          default: 'balanced',
+          description: 'Protection level: strict (block all risky), balanced (block dangerous, confirm risky), permissive (only block critical)',
+        },
+      },
+    },
+  };
+}
+
+function enableOpenClawPlugin(configPath: string, pluginDir: string): void {
+  let config: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    const raw = readFileSync(configPath, 'utf8').trim();
+    config = raw ? JSON.parse(raw) as Record<string, unknown> : {};
+  }
+
+  const plugins = ensureRecord(config, 'plugins');
+  const load = ensureRecord(plugins, 'load');
+  const entries = ensureRecord(plugins, 'entries');
+  const agentguard = ensureRecord(entries, 'agentguard');
+  agentguard.enabled = true;
+
+  const paths = Array.isArray(load.paths) ? load.paths.filter((p): p is string => typeof p === 'string') : [];
+  if (!paths.includes(pluginDir)) {
+    paths.push(pluginDir);
+  }
+  load.paths = paths;
+
+  if (Array.isArray(plugins.allow)) {
+    const allow = plugins.allow.filter((id): id is string => typeof id === 'string');
+    if (!allow.includes('agentguard')) {
+      allow.push('agentguard');
+    }
+    plugins.allow = allow;
+  }
+
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+}
+
+function ensureRecord(parent: Record<string, unknown>, key: string): Record<string, unknown> {
+  const existing = parent[key];
+  if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+    return existing as Record<string, unknown>;
+  }
+  const next: Record<string, unknown> = {};
+  parent[key] = next;
+  return next;
 }

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -1,0 +1,6 @@
+export { default } from './adapters/openclaw-plugin.js';
+export {
+  getPluginIdFromTool,
+  getPluginScanResult,
+  registerOpenClawPlugin,
+} from './adapters/openclaw-plugin.js';

--- a/src/tests/installer.test.ts
+++ b/src/tests/installer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, mkdtempSync } from 'node:fs';
+import { existsSync, readFileSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installAgentTemplates } from '../installers.js';
@@ -23,12 +23,33 @@ describe('Agent template installers', () => {
     assert.ok(readFileSync(join(dir, '.codex', 'agentguard-hook.example.json'), 'utf8').includes('AGENTGUARD_AGENT_HOST=codex'));
   });
 
-  it('writes OpenClaw plugin template', () => {
+  it('writes and enables OpenClaw plugin template', () => {
     const dir = mkdtempSync(join(tmpdir(), 'agentguard-openclaw-'));
+    const result = installAgentTemplates('openclaw', { cwd: dir });
+
+    const pluginDir = join(dir, '.openclaw', 'plugins', 'agentguard');
+    const template = readFileSync(join(pluginDir, 'index.ts'), 'utf8');
+    const manifest = readFileSync(join(pluginDir, 'openclaw.plugin.json'), 'utf8');
+    const config = JSON.parse(readFileSync(join(dir, '.openclaw', 'openclaw.json'), 'utf8'));
+
+    assert.equal(result.files.length, 3);
+    assert.ok(template.includes('registerOpenClawPlugin'));
+    assert.ok(manifest.includes('"id": "agentguard"'));
+    assert.equal(config.plugins.entries.agentguard.enabled, true);
+    assert.deepEqual(config.plugins.load.paths, [pluginDir]);
+    assert.ok(!template.includes("level: 'balanced'"));
+  });
+
+  it('adds AgentGuard to an existing OpenClaw plugin allowlist', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agentguard-openclaw-existing-'));
+    const configPath = join(dir, '.openclaw', 'openclaw.json');
+    mkdirSync(join(dir, '.openclaw'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ plugins: { allow: ['existing'] } }, null, 2));
+
     installAgentTemplates('openclaw', { cwd: dir });
 
-    const template = readFileSync(join(dir, 'openclaw.agentguard.plugin.ts'), 'utf8');
-    assert.ok(template.includes('registerOpenClawPlugin'));
-    assert.ok(!template.includes("level: 'balanced'"));
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    assert.deepEqual(config.plugins.allow, ['existing', 'agentguard']);
+    assert.equal(config.plugins.entries.agentguard.enabled, true);
   });
 });


### PR DESCRIPTION
## Summary

- Enable the AgentGuard OpenClaw plugin when installing via `setup.sh`
- Enable the plugin when running `agentguard init --agent openclaw`
- Add a dedicated OpenClaw package entrypoint so OpenClaw loads the runtime plugin
- Add `@goplus/agentguard/openclaw` root shim files for documented imports
- Document the OpenClaw install behavior and update the changelog
- Keep `/agentguard` skill CLI passthrough docs aligned with actual CLI commands and flags

## Verification

- `npm run build`
- `node --test dist/tests/installer.test.js`
- `bash -n setup.sh`
- `git diff --check`
- Verified `node dist/cli.js init --agent openclaw` writes `plugins.entries.agentguard.enabled = true`

## Type

- [ ] Bug fix
- [ ] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [ ] `npm run build` passes
- [ ] `npm test` passes (32 tests)
- [ ] Manually tested the change

## Related Issues

Closes #
