### PR TITLE
Add cloud disconnect command

### DIFF
--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -80,6 +80,7 @@ Supported CLI commands and options:
 |---|---|---|
 | `agentguard init` | `--level <level>`, `--agent <agent>`, `--cloud <url>`, `--force` | Creates local config and optionally installs agent templates |
 | `agentguard connect` | `--key <key>`, `--api-key <key>`, `--url <url>`, `--cloud <url>` | Prefer `AGENTGUARD_API_KEY` over passing secrets in flags |
+| `agentguard disconnect` | none | Removes local Cloud API key, connection timestamp, pending event spool, and cached Cloud policy; keeps Cloud URL, audit log, and installed hooks/templates |
 | `agentguard status` | none | Shows local config, Cloud URL/API key status, policy cache, audit path |
 | `agentguard policy pull` | `--json` | Pulls Cloud effective runtime policy into the local cache |
 | `agentguard doctor` | none | Checks local setup and Cloud reachability when connected |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { AgentGuardCloudClient } from './cloud/client.js';
 import {
   connectCloud,
+  disconnectCloud,
   ensureConfig,
   getAgentGuardPaths,
   loadConfig,
@@ -91,6 +92,16 @@ async function main() {
         console.log(`Saved Cloud configuration for ${config.cloudUrl}.`);
         console.log(`Policy fetch failed; local protection still works offline. ${error instanceof Error ? error.message : ''}`.trim());
       }
+    });
+
+  program
+    .command('disconnect')
+    .description('Disconnect local AgentGuard from AgentGuard Cloud')
+    .action(() => {
+      const config = disconnectCloud();
+      console.log('Disconnected from AgentGuard Cloud.');
+      console.log('Removed local Cloud API key, connection timestamp, pending event spool, and cached Cloud policy.');
+      console.log(`Local protection remains active using the built-in policy. Audit log: ${config.auditPath}`);
     });
 
   program

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -100,6 +100,17 @@ export function connectCloud(options: { apiKey: string; cloudUrl?: string }): Ag
     apiKey: options.apiKey,
     connectedAt: new Date().toISOString(),
   };
+  saveConfig(next);
+  return next;
+}
+
+export function disconnectCloud(): AgentGuardConfig {
+  const current = ensureConfig();
+  const next: AgentGuardConfig = { ...current };
+  delete next.apiKey;
+  delete next.connectedAt;
+  rmSync(current.eventSpoolPath, { force: true });
+  rmSync(current.policyCachePath, { force: true });
   saveConfig(next);
   return next;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export {
   loadConfig as loadAgentGuardConfig,
   saveConfig as saveAgentGuardConfig,
   connectCloud,
+  disconnectCloud,
   getAgentGuardPaths,
   type AgentGuardConfig,
 } from './config.js';

--- a/src/tests/runtime-cloud.test.ts
+++ b/src/tests/runtime-cloud.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { evaluateLocalAction } from '../runtime/evaluator.js';
@@ -8,7 +8,7 @@ import { getDefaultEffectiveRuntimePolicy } from '../runtime/policy.js';
 import { redactText } from '../runtime/redaction.js';
 import { flushEventSpool, spoolEvent } from '../runtime/audit.js';
 import { protectAction } from '../runtime/protect.js';
-import { connectCloud, getAgentGuardPaths } from '../config.js';
+import { connectCloud, disconnectCloud, getAgentGuardPaths } from '../config.js';
 import { AgentGuardCloudClient } from '../cloud/client.js';
 import type { AgentGuardConfig } from '../config.js';
 import type { RuntimeAuditEvent } from '../runtime/types.js';
@@ -54,6 +54,36 @@ describe('Runtime Cloud bridge', () => {
       assert.doesNotThrow(
         () => new AgentGuardCloudClient({ cloudUrl: 'http://127.0.0.1:9', apiKey: 'ag_live_test_key_123456' })
       );
+    } finally {
+      if (previousHome === undefined) delete process.env.AGENTGUARD_HOME;
+      else process.env.AGENTGUARD_HOME = previousHome;
+    }
+  });
+
+  it('disconnects Cloud without deleting the local audit log', () => {
+    const previousHome = process.env.AGENTGUARD_HOME;
+    process.env.AGENTGUARD_HOME = mkdtempSync(join(tmpdir(), 'agentguard-disconnect-'));
+    try {
+      const config = connectCloud({
+        apiKey: 'ag_live_test_key_123456',
+        cloudUrl: 'https://agentguard.example',
+      });
+      writeFileSync(config.eventSpoolPath, `${JSON.stringify(sampleEvent())}\n`);
+      writeFileSync(config.policyCachePath, JSON.stringify(getDefaultEffectiveRuntimePolicy()));
+      writeFileSync(config.auditPath, `${JSON.stringify(sampleEvent())}\n`);
+
+      const disconnected = disconnectCloud();
+      const saved = JSON.parse(readFileSync(getAgentGuardPaths().configPath, 'utf8')) as AgentGuardConfig;
+
+      assert.equal(disconnected.apiKey, undefined);
+      assert.equal(disconnected.connectedAt, undefined);
+      assert.equal(disconnected.cloudUrl, 'https://agentguard.example');
+      assert.equal(saved.apiKey, undefined);
+      assert.equal(saved.connectedAt, undefined);
+      assert.equal(saved.cloudUrl, 'https://agentguard.example');
+      assert.equal(existsSync(config.eventSpoolPath), false);
+      assert.equal(existsSync(config.policyCachePath), false);
+      assert.equal(existsSync(config.auditPath), true);
     } finally {
       if (previousHome === undefined) delete process.env.AGENTGUARD_HOME;
       else process.env.AGENTGUARD_HOME = previousHome;


### PR DESCRIPTION
## Summary

Adds `agentguard disconnect` to remove the local Cloud connection credentials while keeping local protection active.

The command:
- removes `apiKey` and `connectedAt` from local config
- keeps the configured `cloudUrl` for future reconnects
- clears the pending Cloud event spool
- clears the cached Cloud policy so runtime falls back to the built-in local policy
- keeps the local audit log and installed hooks/templates untouched

Also updates the AgentGuard skill CLI documentation and exports `disconnectCloud()`.


## Type

- [ ] Bug fix
- [ ] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- `npm run build`
- `node --test dist/tests/runtime-cloud.test.js`
- `npm test`



