### PR TITLE
Fix OpenClaw entry contract, skill routing, and Cloud runtime flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "openclaw": {
     "extensions": [
       "./dist/openclaw.js"
+    ],
+    "runtimeExtensions": [
+      "./dist/openclaw.js"
     ]
   },
   "bin": {

--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -72,7 +72,9 @@ If no subcommand is given, or the first argument is a path, default to **scan**.
 
 This skill is allowed to run `agentguard *`, so CLI commands and flags are available even when the skill has a higher-level workflow for the same area.
 
-Use CLI passthrough when the user explicitly asks for a concrete `agentguard ...` command, when the command is one of the CLI-only commands below, or when a CLI flag changes semantics that this skill's high-level workflow does not implement.
+The skill's routed subcommands take priority over similarly named CLI commands. Do not route these through the packaged CLI unless the user explicitly prefixes the request with `/agentguard cli`: `scan`, `action`, `patrol`, `trust`, `report`, `config`, `checkup`, `hermes-hooks`.
+
+Use CLI passthrough for the CLI-only commands below, for explicit `/agentguard cli <args...>` requests, or for the targeted `checkup --against-advisory <id>` mode described below.
 
 Supported CLI commands and options:
 
@@ -84,12 +86,15 @@ Supported CLI commands and options:
 | `agentguard status` | none | Shows local config, Cloud URL/API key status, policy cache, audit path |
 | `agentguard policy pull` | `--json` | Pulls Cloud effective runtime policy into the local cache |
 | `agentguard doctor` | none | Checks local setup and Cloud reachability when connected |
-| `agentguard scan <path>` | `--json` | Runs the packaged scanner against a local path |
 | `agentguard protect` | `--agent <agent>`, `--action-type <type>`, `--tool-name <name>`, `--session-id <id>`, `--decision-mode <local-first|cloud>`, `--json` | Evaluates one runtime action from stdin or hook environment |
 | `agentguard subscribe` | `--since <iso>`, `--json`, `--no-report`, `--install-cron`, `--cron-name <name>`, `--interval-minutes <minutes>`, `--force`, `--cron-run` | Pulls Cloud threat advisories and self-checks local skills |
-| `agentguard checkup` | `--against-advisory <id>`, `--json` | CLI threat-feed self-check; without `--against-advisory`, it only prints a tip in the current CLI build |
+| `agentguard checkup --against-advisory <id>` | `--json` | CLI threat-feed self-check for one advisory; this is a targeted mode, not the default health-check workflow |
 
-If the user writes `/agentguard cli <args...>`, execute `agentguard <args...>` directly. If the user writes `/agentguard checkup --against-advisory <id>`, use the CLI command `agentguard checkup --against-advisory <id>` instead of the comprehensive HTML health-report workflow.
+If the user writes `/agentguard cli <args...>`, execute `agentguard <args...>` directly.
+
+Do **not** route plain `/agentguard scan`, `/agentguard action`, `/agentguard patrol`, `/agentguard trust`, `/agentguard report`, `/agentguard config`, `/agentguard checkup`, `/agentguard checkup --json`, or natural-language requests like "run agentguard checkup" through the packaged CLI. Those are this skill's higher-level workflows. Only use the packaged CLI checkup path when the user includes `--against-advisory <id>` or explicitly writes `/agentguard cli checkup ...`.
+
+If the user writes `/agentguard checkup --against-advisory <id>`, use the CLI command `agentguard checkup --against-advisory <id>` instead of the comprehensive HTML health-report workflow.
 
 ## Subcommand: hermes-hooks
 
@@ -640,16 +645,16 @@ web3.tx_policy: 'allow' | 'confirm_high_risk' | 'deny'
 
 ### Operations
 
-**lookup** — `agentguard trust lookup --source <source> --version <version>`
+**lookup** — `node scripts/trust-cli.ts lookup --source <source> --version <version>`
 Query the registry for a skill's trust record.
 
-**attest** — `agentguard trust attest --id <id> --source <source> --version <version> --hash <hash> --trust-level <level> --preset <preset> --reviewed-by <name>`
+**attest** — `node scripts/trust-cli.ts attest --id <id> --source <source> --version <version> --hash <hash> --trust-level <level> --preset <preset> --reviewed-by <name>`
 Create or update a trust record. Use `--preset` for common capability models or provide `--capabilities <json>` for custom.
 
-**revoke** — `agentguard trust revoke --source <source> --reason <reason>`
+**revoke** — `node scripts/trust-cli.ts revoke --source <source> --reason <reason>`
 Revoke trust for a skill. Supports `--source-pattern` for wildcards.
 
-**list** — `agentguard trust list [--trust-level <level>] [--status <status>]`
+**list** — `node scripts/trust-cli.ts list [--trust-level <level>] [--status <status>]`
 List all trust records with optional filters.
 
 ### Script Execution
@@ -754,6 +759,8 @@ If the log file doesn't exist, inform the user that no security events have been
 ## Subcommand: checkup
 
 Run a comprehensive agent health checkup across 6 security dimensions. Generates a visual HTML report with a lobster mascot and opens it in the browser. The lobster's appearance reflects the agent's health: muscular bodybuilder (score 90+), healthy with shield (70–89), tired with coffee (50–69), or sick with bandages (0–49).
+
+Plain `checkup` must always run this comprehensive workflow, even if the user phrases it as `agentguard checkup`. Do not answer that an advisory ID is required. Advisory IDs are optional and only switch to the targeted threat-feed self-check mode described below.
 
 If the arguments include `--against-advisory <id>`, do not run this comprehensive HTML workflow. Instead execute the CLI threat-feed self-check:
 

--- a/src/adapters/openclaw-plugin.ts
+++ b/src/adapters/openclaw-plugin.ts
@@ -636,9 +636,13 @@ function readOpenClawConfigLevel(
     : undefined;
 }
 
+type OpenClawBeforeToolCallResult =
+  | { block: true; blockReason: string }
+  | { ask: true; askReason: string };
+
 function runtimeResultToBeforeToolCallResult(
   result: ProtectResult | null
-): { block: true; blockReason: string } | undefined {
+): OpenClawBeforeToolCallResult | undefined {
   if (!result) return undefined;
 
   const decision = result.decision.decision;
@@ -654,23 +658,27 @@ function runtimeResultToBeforeToolCallResult(
     .filter(Boolean)
     .slice(0, 3)
     .join(', ');
-  const approval = result.approvalId ? ` Approval: ${result.approvalId}.` : '';
   const action = decision === 'require_approval' ? 'requires approval' : 'blocked';
+  const reason =
+    `GoPlus AgentGuard: runtime policy ${action} this OpenClaw tool call` +
+    ` (risk ${result.decision.riskScore}/100, ${result.decision.riskLevel}; policy ${result.decision.policyVersion}).` +
+    (reasonSummary ? ` Reasons: ${reasonSummary}.` : '');
 
+  if (decision === 'require_approval' && result.approvalChannel === 'agent') {
+    return {
+      ask: true,
+      askReason: reason,
+    };
+  }
   return {
     block: true,
-    blockReason:
-      `GoPlus AgentGuard: runtime policy ${action} this OpenClaw tool call` +
-      ` (risk ${result.decision.riskScore}/100, ${result.decision.riskLevel}; policy ${result.decision.policyVersion}).` +
-      (reasonSummary ? ` Reasons: ${reasonSummary}.` : '') +
-      approval,
+    blockReason: reason,
   };
 }
 
 function shouldSurfaceRuntimeApproval(result: ProtectResult): boolean {
   return (
     result.policySource === 'cloud-decision' ||
-    Boolean(result.approvalId) ||
     result.decision.riskScore > 0 ||
     result.decision.reasons.length > 0
   );

--- a/src/adapters/openclaw-plugin.ts
+++ b/src/adapters/openclaw-plugin.ts
@@ -72,6 +72,7 @@ interface OpenClawPluginApi {
   id: string;
   name: string;
   source: string;
+  registrationMode?: string;
   pluginConfig?: Record<string, unknown>;
   on(event: string, handler: (event: unknown, ctx?: unknown) => Promise<unknown>): void;
   on(event: string, options: Record<string, unknown>, handler: (event: unknown, ctx?: unknown) => Promise<unknown>): void;
@@ -353,6 +354,10 @@ export function registerOpenClawPlugin(
   api: OpenClawPluginApi,
   options: OpenClawPluginOptions = {}
 ): void {
+  if (api.registrationMode && api.registrationMode !== 'full') {
+    return;
+  }
+
   const adapter = new OpenClawAdapter();
   const runtimeConfig = loadAgentGuardConfig();
   const configuredLevel = options.level ?? readOpenClawConfigLevel(api.pluginConfig);
@@ -510,6 +515,18 @@ export function registerOpenClawPlugin(
   logger(`[AgentGuard] Registered with OpenClaw (protection level: ${config.level || 'balanced'})`);
 }
 
+export interface OpenClawPluginEntry {
+  (api: OpenClawPluginApi): void;
+  id: string;
+  name: string;
+  description: string;
+  configSchema: {
+    type: 'object';
+    properties: Record<string, unknown>;
+  };
+  register(api: OpenClawPluginApi): void;
+}
+
 function mapOpenClawToolToRuntimeAction(
   toolName: string | undefined,
   event?: unknown
@@ -664,10 +681,41 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Default export for OpenClaw plugin registration
+ * Default export for OpenClaw plugin registration.
+ *
+ * OpenClaw's native plugin contract loads an entry object with register(api),
+ * while older loaders may call the default export directly. Functions are
+ * objects in JavaScript, so this export supports both shapes without routing
+ * OpenClaw through the package root default createAgentGuard() factory.
  *
  * Usage: export default from '@goplus/agentguard/openclaw'
  */
-export default function register(api: OpenClawPluginApi): void {
+function register(api: OpenClawPluginApi): void {
   registerOpenClawPlugin(api);
 }
+
+const openClawEntry = Object.defineProperties(register, {
+  id: { enumerable: true, value: 'agentguard' },
+  name: { enumerable: true, value: 'GoPlus AgentGuard' },
+  description: {
+    enumerable: true,
+    value: 'AI agent security framework - blocks dangerous commands, prevents data leaks, and protects secrets',
+  },
+  configSchema: {
+    enumerable: true,
+    value: {
+      type: 'object',
+      properties: {
+        level: {
+          type: 'string',
+          enum: ['strict', 'balanced', 'permissive'],
+          default: 'balanced',
+          description: 'Protection level: strict (block all risky), balanced (block dangerous, confirm risky), permissive (only block critical)',
+        },
+      },
+    },
+  },
+  register: { enumerable: true, value: register },
+}) as OpenClawPluginEntry;
+
+export default openClawEntry;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -227,7 +227,7 @@ async function main() {
       });
       if (!result) return;
       console.log(formatProtectResult(result, Boolean(options.json)));
-      process.exitCode = exitCodeForDecision(result.decision);
+      process.exitCode = exitCodeForDecision(result.decision, result);
     });
 
   program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -178,7 +178,8 @@ async function main() {
         const client = new AgentGuardCloudClient(config);
         try {
           const status = await client.status();
-          console.log(`✓ Cloud: ${status.status}${status.version ? ` (${status.version})` : ''}`);
+          const label = status.status || (status.ok ? 'ok' : status.service || 'reachable');
+          console.log(`✓ Cloud: ${label}${status.version ? ` (${status.version})` : ''}`);
         } catch {
           console.log('! Cloud: unreachable; local protection remains active');
         }
@@ -397,15 +398,14 @@ async function main() {
 
       let advisory: Advisory | null = null;
       try {
-        const all = await client.pullAdvisories();
-        advisory = all?.find((a) => a.id === advisoryId) ?? null;
+        advisory = await client.getAdvisory(advisoryId);
       } catch (err) {
         console.error(`! Could not reach AgentGuard Cloud: ${(err as Error).message}`);
         process.exitCode = 1;
         return;
       }
       if (!advisory) {
-        console.error(`No advisory with id "${advisoryId}" found in the current feed window.`);
+        console.error(`No advisory with id "${advisoryId}" found in AgentGuard Cloud.`);
         process.exitCode = 1;
         return;
       }

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -72,15 +72,6 @@ export class AgentGuardCloudClient {
     });
   }
 
-  async createApproval(event: RuntimeAuditEvent): Promise<string | null> {
-    this.requireApiKey();
-    const body = await this.request<{ approvalId: string }>('/api/v1/approvals', {
-      method: 'POST',
-      body: JSON.stringify(buildAuditEvent(event)),
-    });
-    return body.data.approvalId || null;
-  }
-
   /**
    * Pull threat-feed advisories newer than `since`. Returns null when the
    * cloud doesn't expose the endpoint yet (404) — callers should treat null

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -13,6 +13,21 @@ import type { Advisory, SelfCheckMatch } from '../feed/types.js';
 interface ApiSuccess<T> {
   success: true;
   data: T;
+  meta?: ApiMeta;
+}
+
+interface ApiErrorEnvelope {
+  success: false;
+  error?: {
+    code?: string;
+    message?: string;
+    details?: unknown;
+  };
+  meta?: ApiMeta;
+}
+
+interface ApiMeta {
+  requestId?: string;
 }
 
 export class AgentGuardCloudClient {
@@ -28,9 +43,8 @@ export class AgentGuardCloudClient {
     return Boolean(this.apiKey);
   }
 
-  async status(): Promise<{ status: string; version?: string }> {
-    const body = await this.request<{ status: string; version?: string }>('/api/v1/status');
-    return body.data;
+  async status(): Promise<{ ok?: boolean; service?: string; status?: string; version?: string; detectors?: number }> {
+    return this.requestData('/api/v1/status', { allowBareSuccess: true });
   }
 
   async fetchEffectivePolicy(): Promise<EffectiveRuntimePolicy> {
@@ -89,6 +103,17 @@ export class AgentGuardCloudClient {
     }
   }
 
+  async getAdvisory(id: string): Promise<Advisory | null> {
+    try {
+      return await this.requestData<Advisory>(`/api/v1/feed/advisories/${encodeURIComponent(id)}`);
+    } catch (err) {
+      if (err instanceof CloudRequestError && err.status === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
   /**
    * Report the outcome of a single advisory self-check. Matches paths are
    * redacted by the caller before they get here. Tolerates 404 so subscribe
@@ -119,6 +144,23 @@ export class AgentGuardCloudClient {
   }
 
   private async request<T = unknown>(path: string, init: RequestInit = {}): Promise<ApiSuccess<T>> {
+    const body = await this.requestJson<T>(path, init);
+    if (isApiSuccess<T>(body)) return body;
+    throw buildCloudRequestError(200, path, body);
+  }
+
+  private async requestData<T = unknown>(
+    path: string,
+    init: RequestInit & { allowBareSuccess?: boolean } = {}
+  ): Promise<T> {
+    const { allowBareSuccess, ...requestInit } = init;
+    const body = await this.requestJson<T>(path, requestInit);
+    if (isApiSuccess<T>(body)) return body.data;
+    if (allowBareSuccess && !hasApiSuccessField(body)) return body as T;
+    throw buildCloudRequestError(200, path, body);
+  }
+
+  private async requestJson<T = unknown>(path: string, init: RequestInit = {}): Promise<ApiSuccess<T> | ApiErrorEnvelope | T | null> {
     const response = await fetch(`${this.cloudUrl}${path}`, {
       ...init,
       headers: {
@@ -128,9 +170,9 @@ export class AgentGuardCloudClient {
       },
       signal: AbortSignal.timeout(5000),
     });
-    const body = (await response.json().catch(() => null)) as ApiSuccess<T> | null;
-    if (!response.ok || !body?.success) {
-      throw new CloudRequestError(response.status, path);
+    const body = (await response.json().catch(() => null)) as ApiSuccess<T> | ApiErrorEnvelope | T | null;
+    if (!response.ok) {
+      throw buildCloudRequestError(response.status, path, body);
     }
     return body;
   }
@@ -145,11 +187,41 @@ export class AgentGuardCloudClient {
 export class CloudRequestError extends Error {
   constructor(
     public readonly status: number,
-    public readonly path: string
+    public readonly path: string,
+    public readonly code?: string,
+    message?: string,
+    public readonly requestId?: string,
+    public readonly details?: unknown
   ) {
-    super(`AgentGuard Cloud request failed: ${status} (${path})`);
+    super(message ? `AgentGuard Cloud request failed: ${status} (${path}): ${message}` : `AgentGuard Cloud request failed: ${status} (${path})`);
     this.name = 'CloudRequestError';
   }
+}
+
+function isApiSuccess<T>(body: unknown): body is ApiSuccess<T> {
+  return Boolean(body) && typeof body === 'object' && (body as { success?: unknown }).success === true;
+}
+
+function isApiErrorEnvelope(body: unknown): body is ApiErrorEnvelope {
+  return Boolean(body) && typeof body === 'object' && (body as { success?: unknown }).success === false;
+}
+
+function hasApiSuccessField(body: unknown): boolean {
+  return body !== null && typeof body === 'object' && 'success' in body;
+}
+
+function buildCloudRequestError(status: number, path: string, body: unknown): CloudRequestError {
+  if (isApiErrorEnvelope(body)) {
+    return new CloudRequestError(
+      status,
+      path,
+      body.error?.code,
+      body.error?.message,
+      body.meta?.requestId,
+      body.error?.details
+    );
+  }
+  return new CloudRequestError(status, path);
 }
 
 function sanitizeActionRequest(action: RuntimeAction): RuntimeAction {

--- a/src/feed/types.ts
+++ b/src/feed/types.ts
@@ -12,7 +12,13 @@
  */
 
 /** Supply-chain ecosystem an advisory targets. */
-export type AdvisoryEcosystem = 'skill' | 'plugin' | 'mcp_server';
+export type AdvisoryEcosystem =
+  | 'skill'
+  | 'plugin'
+  | 'mcp_server'
+  | 'supply_chain'
+  | 'url'
+  | 'prompt_injection';
 
 export type AdvisorySeverity = 'low' | 'medium' | 'high' | 'critical';
 
@@ -46,6 +52,10 @@ export interface AdvisoryAffected {
    * a code/text pattern rather than a known hash.
    */
   bodyRegex?: string;
+  /** Optional URL glob/regex-style pattern for URL-focused advisories. */
+  urlPattern?: string;
+  /** Optional exact domain match for URL/domain-focused advisories. */
+  domainExact?: string;
 }
 
 export interface Advisory {
@@ -71,6 +81,12 @@ export interface Advisory {
   signature?: string;
   /** External references — Snyk, NVD, GHSA, blog posts. */
   references?: string[];
+  selfCheck?: {
+    inspectPaths?: string[];
+    matchers: unknown[];
+    remediationAction?: 'quarantine' | 'uninstall' | 'block_url' | 'revoke_token' | 'notify_only';
+    remediationMd?: string;
+  };
 }
 
 /**

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -42,17 +42,19 @@ function installOpenClaw(cwd: string | undefined, force: boolean): InstallResult
     ? join(cwd, '.openclaw')
     : process.env.OPENCLAW_STATE_DIR || join(homedir(), '.openclaw');
   const pluginDir = join(openClawRoot, 'plugins', 'agentguard');
-  const pluginPath = join(pluginDir, 'index.ts');
+  const packagePath = join(pluginDir, 'package.json');
+  const pluginPath = join(pluginDir, 'index.js');
   const manifestPath = join(pluginDir, 'openclaw.plugin.json');
   const configPath = cwd
     ? join(openClawRoot, 'openclaw.json')
     : process.env.OPENCLAW_CONFIG_PATH || join(openClawRoot, 'openclaw.json');
 
+  writeIfAllowed(packagePath, JSON.stringify(openClawPackageManifest(), null, 2) + '\n', force);
   writeIfAllowed(pluginPath, openClawPluginTemplate(), force);
   writeIfAllowed(manifestPath, JSON.stringify(openClawPluginManifest(), null, 2) + '\n', force);
   enableOpenClawPlugin(configPath, pluginDir);
 
-  return { agent: 'openclaw', files: [pluginPath, manifestPath, configPath] };
+  return { agent: 'openclaw', files: [packagePath, pluginPath, manifestPath, configPath] };
 }
 
 function writeIfAllowed(path: string, content: string, force: boolean): void {
@@ -151,14 +153,36 @@ function codexHookTemplate(): unknown {
 }
 
 function openClawPluginTemplate(): string {
-  return `import { registerOpenClawPlugin } from '@goplus/agentguard';
+  return `const { registerOpenClawPlugin } = require('@goplus/agentguard');
 
-export default function setup(api) {
+function register(api) {
   registerOpenClawPlugin(api, {
     skipAutoScan: false,
   });
 }
+
+module.exports = Object.defineProperties(register, {
+  id: { enumerable: true, value: 'agentguard' },
+  name: { enumerable: true, value: 'GoPlus AgentGuard' },
+  description: {
+    enumerable: true,
+    value: 'AI agent security framework - blocks dangerous commands, prevents data leaks, and protects secrets',
+  },
+  register: { enumerable: true, value: register },
+});
 `;
+}
+
+function openClawPackageManifest(): unknown {
+  return {
+    name: 'agentguard-openclaw-local',
+    private: true,
+    type: 'commonjs',
+    openclaw: {
+      extensions: ['./index.js'],
+      runtimeExtensions: ['./index.js'],
+    },
+  };
 }
 
 function openClawPluginManifest(): unknown {

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -133,7 +133,7 @@ Expected decisions:
 
 - \`allow\`: continue
 - \`warn\`: show warning and continue
-- \`confirm\`: ask for approval before continuing
+- \`confirm\`: ask for approval in the agent channel before continuing
 - \`block\`: stop the action
 `;
 }

--- a/src/runtime/protect.ts
+++ b/src/runtime/protect.ts
@@ -20,7 +20,7 @@ export interface ProtectOptions {
 export interface ProtectResult {
   decision: RuntimeDecision;
   event: RuntimeAuditEvent;
-  approvalId?: string | null;
+  approvalChannel?: 'agent' | null;
   policySource: 'cloud' | 'cache' | 'default' | 'cloud-decision';
 }
 
@@ -68,18 +68,23 @@ export async function protectAction(options: ProtectOptions): Promise<ProtectRes
     // Audit I/O must not mask the policy decision, especially for agent hooks.
   }
 
-  let approvalId: string | null | undefined;
+  let approvalChannel: ProtectResult['approvalChannel'];
   if (client.connected && policySource !== 'cloud-decision') {
     await client.ingestEvents([event]).catch(() => spoolEvent(options.config.eventSpoolPath, event));
   }
-  if (client.connected && decision.decision === 'require_approval') {
-    approvalId = await client.createApproval(event).catch(() => null);
+  if (decision.decision === 'require_approval') {
+    approvalChannel = 'agent';
   }
 
-  return { decision, event, approvalId, policySource };
+  return { decision, event, approvalChannel, policySource };
 }
 
 export function formatProtectResult(result: ProtectResult, json = false): string {
+  if (!json) {
+    const agentApproval = formatAgentApproval(result);
+    if (agentApproval) return agentApproval;
+  }
+
   if (json) {
     return JSON.stringify({
       decision: publicDecision(result.decision.decision),
@@ -88,7 +93,7 @@ export function formatProtectResult(result: ProtectResult, json = false): string
       riskScore: result.decision.riskScore,
       riskLevel: result.decision.riskLevel,
       reasons: result.decision.reasons,
-      approvalId: result.approvalId,
+      approvalChannel: result.approvalChannel,
       policySource: result.policySource,
     }, null, 2);
   }
@@ -98,8 +103,7 @@ export function formatProtectResult(result: ProtectResult, json = false): string
     return `BLOCKED by AgentGuard (action: ${result.decision.actionId}, risk: ${result.decision.riskScore}/100, level: ${result.decision.riskLevel}, reasons: ${reasonCount}).`;
   }
   if (result.decision.decision === 'require_approval') {
-    const approval = result.approvalId ? `approval: ${result.approvalId}, ` : '';
-    return `CONFIRM required by AgentGuard (${approval}action: ${result.decision.actionId}, risk: ${result.decision.riskScore}/100, level: ${result.decision.riskLevel}, reasons: ${reasonCount}).`;
+    return `CONFIRM required by AgentGuard (action: ${result.decision.actionId}, risk: ${result.decision.riskScore}/100, level: ${result.decision.riskLevel}, reasons: ${reasonCount}).`;
   }
   if (result.decision.decision === 'warn') {
     return `WARN from AgentGuard (action: ${result.decision.actionId}, risk: ${result.decision.riskScore}/100, level: ${result.decision.riskLevel}, reasons: ${reasonCount}).`;
@@ -107,12 +111,55 @@ export function formatProtectResult(result: ProtectResult, json = false): string
   return 'ALLOW by AgentGuard.';
 }
 
-export function exitCodeForDecision(decision: RuntimeDecision): number {
+export function exitCodeForDecision(decision: RuntimeDecision, result?: Pick<ProtectResult, 'approvalChannel'>): number {
+  if (decision.decision === 'require_approval' && result?.approvalChannel === 'agent') return 0;
   return decision.decision === 'block' || decision.decision === 'require_approval' ? 2 : 0;
 }
 
 function publicDecision(decision: RuntimeDecision['decision']): 'allow' | 'warn' | 'confirm' | 'block' {
   return decision === 'require_approval' ? 'confirm' : decision;
+}
+
+function formatAgentApproval(result: ProtectResult): string | null {
+  if (result.decision.decision !== 'require_approval' || result.approvalChannel !== 'agent') return null;
+
+  const reason = formatApprovalReason(result);
+  if (result.event.agentHost === 'claude-code') {
+    return JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'ask',
+        permissionDecisionReason: reason,
+      },
+    });
+  }
+
+  if (result.event.agentHost === 'codex') {
+    return JSON.stringify({
+      decision: 'confirm',
+      actionId: result.decision.actionId,
+      riskScore: result.decision.riskScore,
+      riskLevel: result.decision.riskLevel,
+      reasons: result.decision.reasons,
+      approvalChannel: 'agent',
+      message: reason,
+    }, null, 2);
+  }
+
+  return null;
+}
+
+function formatApprovalReason(result: ProtectResult): string {
+  const reasonSummary = result.decision.reasons
+    .map((reason) => reason.title)
+    .filter(Boolean)
+    .slice(0, 3)
+    .join(', ');
+  return (
+    `GoPlus AgentGuard requires approval for this action` +
+    ` (action: ${result.decision.actionId}, risk: ${result.decision.riskScore}/100, level: ${result.decision.riskLevel}).` +
+    (reasonSummary ? ` Reasons: ${reasonSummary}.` : '')
+  );
 }
 
 function buildRuntimeAction(options: ProtectOptions): RuntimeAction {

--- a/src/tests/cloud-live.test.ts
+++ b/src/tests/cloud-live.test.ts
@@ -33,24 +33,6 @@ describe('Cloud live integration', { skip: !runLive }, () => {
     await client.ingestEvents([event]);
   });
 
-  it('creates a Cloud approval request', async () => {
-    const event = sampleEvent('require_approval');
-    event.input = '/tmp/.env?token=live-secret-that-must-be-redacted';
-    event.riskScore = 55;
-    event.riskLevel = 'high';
-    event.reasons = [
-      {
-        code: 'SECRET_ACCESS',
-        severity: 'high',
-        title: 'Live test protected path access',
-        description: 'Live integration test verifies approval creation.',
-        evidence: '/tmp/.env?token=live-secret-that-must-be-redacted',
-      },
-    ];
-
-    const approvalId = await client.createApproval(event);
-    assert.ok(approvalId);
-  });
 });
 
 function sampleEvent(decision: RuntimeAuditEvent['decision']): RuntimeAuditEvent {

--- a/src/tests/feed-cloud.test.ts
+++ b/src/tests/feed-cloud.test.ts
@@ -40,6 +40,23 @@ describe('cloud client — feed methods', () => {
     server.close();
   });
 
+  it('status accepts the public bare status response', async () => {
+    nextResponse = {
+      status: 200,
+      body: {
+        ok: true,
+        service: 'AgentGuard API',
+        version: '1.0.0',
+        detectors: 8,
+      },
+    };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl });
+    const result = await client.status();
+    assert.equal(result.ok, true);
+    assert.equal(result.service, 'AgentGuard API');
+    assert.equal(result.version, '1.0.0');
+  });
+
   it('pullAdvisories returns advisories on 200', async () => {
     nextResponse = {
       status: 200,
@@ -75,9 +92,54 @@ describe('cloud client — feed methods', () => {
   });
 
   it('pullAdvisories throws on other errors', async () => {
-    nextResponse = { status: 500, body: { success: false, error: { message: 'boom' } } };
+    nextResponse = {
+      status: 500,
+      body: {
+        success: false,
+        error: { code: 'CLOUD_DOWN', message: 'boom', details: { retry: true } },
+        meta: { requestId: 'req_test' },
+      },
+    };
     const client = new AgentGuardCloudClient({ cloudUrl: baseUrl, apiKey: 'ag_live_x' });
-    await assert.rejects(() => client.pullAdvisories(), (err: unknown) => err instanceof CloudRequestError && err.status === 500);
+    await assert.rejects(
+      () => client.pullAdvisories(),
+      (err: unknown) =>
+        err instanceof CloudRequestError &&
+        err.status === 500 &&
+        err.code === 'CLOUD_DOWN' &&
+        err.message.includes('boom') &&
+        err.requestId === 'req_test'
+    );
+  });
+
+  it('getAdvisory fetches a single advisory by id', async () => {
+    nextResponse = {
+      status: 200,
+      body: {
+        success: true,
+        data: {
+          id: 'AGS-2026-0042',
+          ecosystem: 'url',
+          severity: 'critical',
+          summary: 'bad url',
+          detailsMd: '',
+          affected: [{ domainExact: 'evil.example' }],
+          publishedAt: '2026-05-13T00:00:00Z',
+        },
+      },
+    };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl, apiKey: 'ag_live_x' });
+    const result = await client.getAdvisory('AGS-2026-0042');
+    assert.equal(result?.id, 'AGS-2026-0042');
+    assert.equal(result?.ecosystem, 'url');
+    assert.match(lastRequest!.url, /\/api\/v1\/feed\/advisories\/AGS-2026-0042$/);
+  });
+
+  it('getAdvisory returns null on 404', async () => {
+    nextResponse = { status: 404, body: { success: false, error: { message: 'not found' } } };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl, apiKey: 'ag_live_x' });
+    const result = await client.getAdvisory('AGS-missing');
+    assert.equal(result, null);
   });
 
   it('reportSelfCheck POSTs the advisoryId + matches', async () => {

--- a/src/tests/installer.test.ts
+++ b/src/tests/installer.test.ts
@@ -28,12 +28,17 @@ describe('Agent template installers', () => {
     const result = installAgentTemplates('openclaw', { cwd: dir });
 
     const pluginDir = join(dir, '.openclaw', 'plugins', 'agentguard');
-    const template = readFileSync(join(pluginDir, 'index.ts'), 'utf8');
+    const packageJson = JSON.parse(readFileSync(join(pluginDir, 'package.json'), 'utf8'));
+    const template = readFileSync(join(pluginDir, 'index.js'), 'utf8');
     const manifest = readFileSync(join(pluginDir, 'openclaw.plugin.json'), 'utf8');
     const config = JSON.parse(readFileSync(join(dir, '.openclaw', 'openclaw.json'), 'utf8'));
 
-    assert.equal(result.files.length, 3);
+    assert.equal(result.files.length, 4);
+    assert.deepEqual(packageJson.openclaw.extensions, ['./index.js']);
+    assert.deepEqual(packageJson.openclaw.runtimeExtensions, ['./index.js']);
     assert.ok(template.includes('registerOpenClawPlugin'));
+    assert.ok(template.includes('skipAutoScan: false'));
+    assert.ok(template.includes('register: { enumerable: true, value: register }'));
     assert.ok(manifest.includes('"id": "agentguard"'));
     assert.equal(config.plugins.entries.agentguard.enabled, true);
     assert.deepEqual(config.plugins.load.paths, [pluginDir]);

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { evaluateHook } from '../adapters/engine.js';
 import { registerOpenClawPlugin } from '../adapters/openclaw-plugin.js';
+import openClawEntry from '../openclaw.js';
 import { createTestContext } from './helpers/test-utils.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -122,6 +123,29 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
     });
     assert.ok(handlers['before_tool_call'], 'Should register before_tool_call');
     assert.ok(handlers['after_tool_call'], 'Should register after_tool_call');
+  });
+
+  it('exports an OpenClaw entry that supports register(api) and direct legacy calls', () => {
+    const viaRegister = createMockApi();
+    openClawEntry.register(viaRegister.api as never);
+
+    const viaDirectCall = createMockApi();
+    openClawEntry(viaDirectCall.api as never);
+
+    assert.equal(openClawEntry.id, 'agentguard');
+    assert.ok(viaRegister.handlers['before_tool_call']);
+    assert.ok(viaRegister.handlers['after_tool_call']);
+    assert.ok(viaDirectCall.handlers['before_tool_call']);
+    assert.ok(viaDirectCall.handlers['after_tool_call']);
+  });
+
+  it('does not register runtime hooks during non-full OpenClaw loads', () => {
+    const { api, handlers } = createMockApi();
+    registerOpenClawPlugin({ ...api, registrationMode: 'discovery' } as never, {
+      skipAutoScan: false,
+    });
+
+    assert.deepEqual(handlers, {});
   });
 
   it('should auto-scan plugins from OpenClaw activeRegistry state', async () => {

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -371,7 +371,6 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
       registry: ctx.agentguard.registry as never,
       protectAction: async () => ({
         policySource: 'cloud-decision',
-        approvalId: null,
         event: {} as never,
         decision: {
           actionId: 'act_test',
@@ -401,6 +400,44 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
     assert.ok(result?.blockReason?.includes('cloud-test'));
   });
 
+  it('should ask in the OpenClaw agent channel when runtime policy requires approval', async () => {
+    ctx = createTestContext();
+    const { api, handlers } = createMockApi();
+    registerOpenClawPlugin(api as never, {
+      skipAutoScan: true,
+      registry: ctx.agentguard.registry as never,
+      protectAction: async () => ({
+        policySource: 'cloud',
+        approvalChannel: 'agent',
+        event: {} as never,
+        decision: {
+          actionId: 'act_approval',
+          decision: 'require_approval',
+          riskScore: 80,
+          riskLevel: 'high',
+          policyVersion: 'cloud-test',
+          reasons: [
+            {
+              code: 'SECRET_ACCESS',
+              severity: 'high',
+              title: 'Protected path',
+              description: 'Protected path access requires approval.',
+            },
+          ],
+        },
+      }),
+    });
+
+    const result = await handlers['before_tool_call']({
+      toolName: 'Read',
+      params: { path: '/workspace/.env' },
+    }) as { ask?: boolean; askReason?: string } | undefined;
+
+    assert.equal(result?.ask, true);
+    assert.ok(result?.askReason?.includes('requires approval'));
+    assert.ok(result?.askReason?.includes('Protected path'));
+  });
+
   it('should return { block: true } for rm -rf /', async () => {
     ctx = createTestContext();
     const { api, handlers } = createMockApi();
@@ -419,7 +456,7 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
     assert.ok(result!.blockReason?.includes('AgentGuard'), 'Reason should mention AgentGuard');
   });
 
-  it('should block write to .env via OpenClaw', async () => {
+  it('should ask before writing .env via OpenClaw', async () => {
     ctx = createTestContext();
     const { api, handlers } = createMockApi();
     registerOpenClawPlugin(api as never, {
@@ -430,9 +467,10 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
     const result = await handlers['before_tool_call']({
       toolName: 'write',
       params: { path: '/project/.env' },
-    }) as { block?: boolean } | undefined;
+    }) as { ask?: boolean; askReason?: string } | undefined;
 
-    assert.ok(result?.block, 'Should block write to .env');
+    assert.ok(result?.ask, 'Should ask before writing .env');
+    assert.ok(result?.askReason?.includes('requires approval'));
   });
 
   it('should handle after_tool_call without error', async () => {

--- a/src/tests/runtime-cloud.test.ts
+++ b/src/tests/runtime-cloud.test.ts
@@ -7,7 +7,8 @@ import { evaluateLocalAction } from '../runtime/evaluator.js';
 import { getDefaultEffectiveRuntimePolicy } from '../runtime/policy.js';
 import { redactText } from '../runtime/redaction.js';
 import { flushEventSpool, spoolEvent } from '../runtime/audit.js';
-import { protectAction } from '../runtime/protect.js';
+import { exitCodeForDecision, formatProtectResult, protectAction } from '../runtime/protect.js';
+import type { ProtectResult } from '../runtime/protect.js';
 import { connectCloud, disconnectCloud, getAgentGuardPaths } from '../config.js';
 import { AgentGuardCloudClient } from '../cloud/client.js';
 import type { AgentGuardConfig } from '../config.js';
@@ -200,7 +201,7 @@ describe('Runtime Cloud bridge', () => {
     assert.equal(result?.decision.decision, 'block');
   });
 
-  it('syncs redacted audit events and creates Cloud approval on require_approval', async () => {
+  it('syncs redacted audit events and uses agent approval by default on require_approval', async () => {
     const originalFetch = globalThis.fetch;
     const dir = mkdtempSync(join(tmpdir(), 'agentguard-cloud-ok-'));
     const policy = getDefaultEffectiveRuntimePolicy();
@@ -216,17 +217,6 @@ describe('Runtime Cloud bridge', () => {
       }
       if (url.endsWith('/api/v1/events/ingest')) {
         return jsonResponse({ success: true, data: { accepted: 1, rejected: 0 } }, 202);
-      }
-      if (url.endsWith('/api/v1/approvals')) {
-        return jsonResponse({
-          success: true,
-          data: {
-            approvalId: 'apr_test',
-            actionId: 'act_test',
-            sessionId: 'sess_test',
-            status: 'pending',
-          },
-        }, 202);
       }
       return jsonResponse({ success: false, error: { message: 'not found' } }, 404);
     }) as typeof fetch;
@@ -254,14 +244,42 @@ describe('Runtime Cloud bridge', () => {
       });
 
       assert.equal(result?.decision.decision, 'require_approval');
-      assert.equal(result?.approvalId, 'apr_test');
+      assert.equal(result?.approvalChannel, 'agent');
       assert.ok(requests.some((request) => request.url.endsWith('/api/v1/events/ingest')));
-      assert.ok(requests.some((request) => request.url.endsWith('/api/v1/approvals')));
+      assert.equal(requests.some((request) => request.url.endsWith('/api/v1/approvals')), false);
       assert.ok(!requests.map((request) => request.body || '').join('\n').includes('secret-value'));
       assert.ok(requests.map((request) => request.body || '').join('\n').includes('[REDACTED]'));
+      assert.equal(exitCodeForDecision(result!.decision, result!), 0);
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it('formats Claude Code agent approval as a PreToolUse ask response', () => {
+    const result: ProtectResult = {
+      policySource: 'cloud',
+      approvalChannel: 'agent',
+      event: { ...sampleEvent(), agentHost: 'claude-code' as const },
+      decision: {
+        actionId: 'act_confirm',
+        decision: 'require_approval' as const,
+        riskScore: 70,
+        riskLevel: 'high' as const,
+        policyVersion: 'runtime-test',
+        reasons: [
+          {
+            code: 'SECRET_ACCESS',
+            severity: 'high' as const,
+            title: 'Protected path',
+            description: 'Protected path access requires approval.',
+          },
+        ],
+      },
+    };
+
+    const formatted = JSON.parse(formatProtectResult(result, false));
+    assert.equal(formatted.hookSpecificOutput.permissionDecision, 'ask');
+    assert.match(formatted.hookSpecificOutput.permissionDecisionReason, /Protected path/);
   });
 });
 


### PR DESCRIPTION
## Summary

This PR fixes several AgentGuard integration issues across OpenClaw, skill command routing, Cloud feed API alignment, and runtime approval UX.

### Changes

- Align OpenClaw plugin entry with the native plugin contract
  - Add dedicated OpenClaw entry export support
  - Add `runtimeExtensions`
  - Update init template to generate OpenClaw-compatible plugin structure

- Preserve AgentGuard skill command routing
  - Keep plain `agentguard checkup` as the full health-check workflow
  - Route only `checkup --against-advisory <id>` to the CLI targeted self-check path

- Align Cloud feed client with the Cloud API design
  - Support public bare `/api/v1/status` response
  - Add single advisory fetch via `/api/v1/feed/advisories/{id}`
  - Parse Cloud error envelope metadata
  - Expand advisory type compatibility with Cloud ecosystems while keeping self-check execution limited to `skill`

- Improve runtime approval UX
  - Runtime risk events are still uploaded to Cloud via event ingest
  - Approval no longer creates or waits on Cloud/web approval records
  - `require_approval` now routes back through the agent channel
  - OpenClaw returns agent-channel `ask` for approval-required runtime actions


## Type

- [✅] Bug fix
- [✅] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [✅] `npm run build` passes
- [✅] `npm test` passes (32 tests)
- [ ] Manually tested the change

## Related Issues

Closes #75 #76 
