### PR TITLE
Support OpenClaw Agent JWT registration and approval alias compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Added Agent JWT registration for OpenClaw-backed installs, allowing `agentguard connect` and `agentguard subscribe` to register a local agent, store `agentId`/JWT credentials, and present an activation URL when no API key is provided.
+- Added AgentGuard Cloud feed subscription support through `POST /api/v1/feed/subscribe`, with default advisory ecosystems for skills, plugins, MCP servers, supply-chain, URL, and prompt-injection advisories.
+- Added OpenClaw delivery of AgentGuard Cloud activation links to the last reachable OpenClaw channel when agent registration is required.
+- `agentguard status` now shows Agent ID, Agent JWT presence, and the saved agent activation URL.
+
+### Changed
+- AgentGuard Cloud requests now authenticate with Agent JWT bearer tokens when available, while retaining API key support.
+- Cloud-facing CLI flows now retry Agent JWT registration on unauthorized responses for policy pulls, advisory fetches, feed subscribe runs, and self-check reports.
+- Manual threat-feed notifications now include advisory remediation guidance when provided by Cloud.
+- OpenClaw manual threat-feed cron prompts now instruct the agent to summarize advisories, preserve IDs and severity labels, and avoid claiming local matches unless the command output explicitly reports them.
+- `agentguard disconnect` now clears Agent JWT registration details in addition to API keys, pending event spools, and cached Cloud policy.
+- API-key based `agentguard connect` now clears any previously stored Agent JWT credentials.
+
+### Fixed
+- Fixed runtime decision compatibility with Cloud responses that use the `require_approve` alias by normalizing it to `require_approval` before enforcing OpenClaw and local runtime decisions.
+- Improved disconnected Cloud guidance so commands direct users to `agentguard connect`, or to OpenClaw Agent JWT registration when available.
+- Strengthened test coverage for Agent JWT connect/reauth flows, OpenClaw registration notifications, feed subscriptions, runtime Cloud auth, policy handling, and cron/manual advisory notifications.
+
 ## [1.1.14] - 2026-05-22
 
 ### Changed

--- a/src/adapters/openclaw-plugin.ts
+++ b/src/adapters/openclaw-plugin.ts
@@ -655,7 +655,7 @@ function runtimeResultToBeforeToolCallResult(
 ): OpenClawBeforeToolCallResult | undefined {
   if (!result) return undefined;
 
-  const decision = result.decision.decision;
+  const decision = normalizeRuntimePolicyDecision(result.decision.decision);
   if (decision !== 'block' && decision !== 'require_approval') {
     return undefined;
   }
@@ -703,6 +703,10 @@ function shouldSurfaceRuntimeApproval(result: ProtectResult): boolean {
     result.decision.riskScore > 0 ||
     result.decision.reasons.length > 0
   );
+}
+
+function normalizeRuntimePolicyDecision(decision: ProtectResult['decision']['decision'] | string): ProtectResult['decision']['decision'] {
+  return decision === 'require_approve' ? 'require_approval' : decision as ProtectResult['decision']['decision'];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -473,10 +473,7 @@ async function main() {
 
       console.log(`Pulled ${advisories.length} advisory record(s); ${fresh.length} new.`);
       if (!quiet && fresh.length > 0) {
-        console.log('New threat-feed advisories found. Review and handle them manually:');
-        for (const advisory of fresh) {
-          console.log(`  - ${advisory.id} [${advisory.severity}] ${advisory.summary}`);
-        }
+        console.log(summary.notification?.body ?? formatNewAdvisoryNotification(fresh));
       } else if (quiet && fresh.length > 0) {
         console.log(`Self-check found ${totalMatches} match(es) across the new advisories.`);
         for (const r of results) {
@@ -1120,12 +1117,29 @@ function formatNewAdvisoryNotification(advisories: Advisory[]): string {
   const lines = ['AgentGuard found new threat-feed advisories that need manual review:'];
   for (const advisory of advisories.slice(0, 10)) {
     lines.push(`- ${advisory.id} [${advisory.severity}] ${advisory.summary}`);
+    const remediation = formatAdvisoryRemediation(advisory);
+    if (remediation) {
+      lines.push('  Remediation guidance:');
+      for (const line of remediation.split('\n')) {
+        lines.push(`  ${line}`);
+      }
+    }
   }
   if (advisories.length > 10) {
     lines.push(`- ... ${advisories.length - 10} more`);
   }
-  lines.push('Run `agentguard subscribe --quiet` to execute the local self-check and report matches automatically.');
   return lines.join('\n');
+}
+
+function formatAdvisoryRemediation(advisory: Advisory): string | null {
+  const remediation = advisory.selfCheck?.remediationMd?.trim();
+  if (!remediation) return null;
+  const compact = remediation
+    .replace(/\r\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  const maxLen = 1200;
+  return compact.length > maxLen ? `${compact.slice(0, maxLen).trimEnd()}\n...` : compact;
 }
 
 function formatThreatFeedNotification(results: SelfCheckResult[]): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ async function main() {
     .option('--cloud <url>', 'AgentGuard Cloud URL to store in local config')
     .option('--force', 'Overwrite existing hook/template files')
     .action((options) => {
-      const config = ensureConfig();
+      let config = ensureConfig();
       if (options.level) {
         if (!['strict', 'balanced', 'permissive'].includes(options.level)) {
           throw new Error('Invalid level. Use strict, balanced, or permissive.');
@@ -123,10 +123,36 @@ async function main() {
         if (!isOpenClawAgentConfigured(config)) {
           throw new Error('Missing API key. Pass --key, --api-key, set AGENTGUARD_API_KEY, or run `agentguard init --agent openclaw` before using Agent JWT registration.');
         }
+        const cloudUrl = normalizeCloudUrl(options.cloud || options.url || config.cloudUrl || 'https://agentguard.gopluslabs.io');
+        if (config.agentId && config.agentJwt) {
+          const existingConfig = { ...config, cloudUrl };
+          const client = new AgentGuardCloudClient(existingConfig);
+          try {
+            const policy = await client.fetchEffectivePolicy();
+            const savedConfig = connectAgentJwt({
+              agentId: config.agentId,
+              agentJwt: config.agentJwt,
+              agentRegisterUrl: config.agentRegisterUrl,
+              cloudUrl,
+            });
+            saveCachedPolicy(savedConfig.policyCachePath, policy);
+            console.log(`Connected to AgentGuard Cloud (${savedConfig.cloudUrl}).`);
+            console.log(`Agent JWT is active for local agent ${savedConfig.agentId}.`);
+            console.log(`Cached policy ${policy.policyVersion} at ${savedConfig.policyCachePath}.`);
+            return;
+          } catch (err) {
+            if (!(err instanceof CloudRequestError && err.status === 401)) {
+              console.log(`Agent JWT is configured for ${cloudUrl}.`);
+              console.log(`Could not verify it right now; local protection still works offline. ${err instanceof Error ? err.message : ''}`.trim());
+              return;
+            }
+          }
+        }
         const registration = await registerAgentCredential({
-          cloudUrl: options.cloud || options.url,
+          cloudUrl,
           reason: 'connect',
           notifyOpenClaw: true,
+          resetExistingJwt: true,
         });
         console.log(`Registered local AgentGuard agent (${registration.config.agentId}).`);
         console.log('Open this link to bind AgentGuard Cloud to your email:');
@@ -190,8 +216,8 @@ async function main() {
     .description('Pull the latest effective runtime policy from AgentGuard Cloud into the local cache')
     .option('--json', 'Print JSON output')
     .action(async (options) => {
-      const config = ensureConfig();
-      const client = new AgentGuardCloudClient(config);
+      let config = ensureConfig();
+      let client = new AgentGuardCloudClient(config);
       if (!client.connected) {
         const message = 'AgentGuard Cloud is not connected. Run `agentguard connect` first.';
         if (options.json) {
@@ -204,7 +230,16 @@ async function main() {
       }
 
       try {
-        const pulledPolicy = await client.fetchEffectivePolicy();
+        const result = await runCloudRequestWithAgentJwtReauth({
+          config,
+          client,
+          reason: 'reauth',
+          notifyOpenClaw: true,
+          operation: (activeClient) => activeClient.fetchEffectivePolicy(),
+        });
+        config = result.config;
+        client = result.client;
+        const pulledPolicy = result.value;
         saveCachedPolicy(config.policyCachePath, pulledPolicy);
         if (options.json) {
           console.log(JSON.stringify({
@@ -275,8 +310,8 @@ async function main() {
       console.log(`✓ Home: ${paths.home}`);
       console.log(`✓ Config: ${paths.configPath}`);
       console.log(`✓ Node: ${process.version}`);
-      if (config.apiKey) {
-        const client = new AgentGuardCloudClient(config);
+      const client = new AgentGuardCloudClient(config);
+      if (client.connected) {
         try {
           const status = await client.status();
           const label = status.status || (status.ok ? 'ok' : status.service || 'reachable');
@@ -521,10 +556,19 @@ async function main() {
             // match, we must NOT mark the advisory seen, otherwise a
             // transient network blip silently buries a real hit.
             try {
-              await client.reportSelfCheck(advisory.id, result.matchedArtifacts, {
-                elapsedMs: result.elapsedMs,
-                warnings: result.warnings,
+              const reportResult = await runCloudRequestWithAgentJwtReauth({
+                config,
+                client,
+                reason: 'reauth',
+                notifyOpenClaw: resolveCronAgentHost(config) === 'openclaw',
+                operation: (activeClient) => activeClient.reportSelfCheck(advisory.id, result.matchedArtifacts, {
+                  elapsedMs: result.elapsedMs,
+                  warnings: result.warnings,
+                }),
               });
+              config = reportResult.config;
+              client = reportResult.client;
+              if (reportResult.registration) registration = reportResult.registration;
             } catch (err) {
               console.error(`! Failed to report self-check for ${advisory.id}: ${(err as Error).message}`);
               processed = false;
@@ -644,7 +688,7 @@ async function main() {
     .option('--against-advisory <id>', 'Restrict the check to a single advisory id (fetches it from Cloud if needed)')
     .option('--json', 'Emit machine-readable result')
     .action(async (options) => {
-      const config = ensureConfig();
+      let config = ensureConfig();
       const advisoryId = options.againstAdvisory as string | undefined;
 
       if (!advisoryId) {
@@ -664,7 +708,7 @@ async function main() {
         return;
       }
 
-      const client = new AgentGuardCloudClient(config);
+      let client = new AgentGuardCloudClient(config);
       if (!client.connected) {
         const message = 'AgentGuard Cloud is not connected. Run `agentguard connect` first.';
         if (options.json) {
@@ -678,9 +722,23 @@ async function main() {
 
       let advisory: Advisory | null = null;
       try {
-        advisory = await client.getAdvisory(advisoryId);
+        const result = await runCloudRequestWithAgentJwtReauth({
+          config,
+          client,
+          reason: 'reauth',
+          notifyOpenClaw: true,
+          operation: (activeClient) => activeClient.getAdvisory(advisoryId),
+        });
+        config = result.config;
+        client = result.client;
+        advisory = result.value;
       } catch (err) {
-        console.error(`! Could not reach AgentGuard Cloud: ${(err as Error).message}`);
+        const message = `Could not reach AgentGuard Cloud: ${(err as Error).message}`;
+        if (options.json) {
+          console.log(JSON.stringify({ success: false, error: message }, null, 2));
+        } else {
+          console.error(`! ${message}`);
+        }
         process.exitCode = 1;
         return;
       }
@@ -1093,6 +1151,50 @@ interface AgentCredentialRegistration {
     notified: boolean;
     reason?: string;
   };
+}
+
+interface AgentJwtReauthResult<T> {
+  value: T;
+  config: AgentGuardConfig;
+  client: AgentGuardCloudClient;
+  registration: AgentCredentialRegistration | null;
+}
+
+async function runCloudRequestWithAgentJwtReauth<T>(options: {
+  config: AgentGuardConfig;
+  client: AgentGuardCloudClient;
+  reason: 'reauth';
+  notifyOpenClaw: boolean;
+  operation: (client: AgentGuardCloudClient) => Promise<T>;
+}): Promise<AgentJwtReauthResult<T>> {
+  try {
+    return {
+      value: await options.operation(options.client),
+      config: options.config,
+      client: options.client,
+      registration: null,
+    };
+  } catch (err) {
+    if (
+      !(err instanceof CloudRequestError && err.status === 401) ||
+      !options.config.agentJwt ||
+      !isOpenClawAgentConfigured(options.config)
+    ) {
+      throw err;
+    }
+    const registration = await registerAgentCredential({
+      cloudUrl: options.config.cloudUrl,
+      reason: options.reason,
+      notifyOpenClaw: options.notifyOpenClaw,
+      resetExistingJwt: true,
+    });
+    return {
+      value: await options.operation(registration.client),
+      config: registration.config,
+      client: registration.client,
+      registration,
+    };
+  }
 }
 
 async function registerAgentCredential(options: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,8 @@ import { Command } from 'commander';
 import { AgentGuardCloudClient } from './cloud/client.js';
 import {
   connectCloud,
+  connectAgentJwt,
+  clearAgentJwt,
   disconnectCloud,
   ensureConfig,
   getAgentGuardPaths,
@@ -26,6 +28,8 @@ import { packageVersion } from './version.js';
 import { runSelfCheckForAdvisory } from './feed/selfcheck.js';
 import { getSeenAdvisoryIds, loadFeedState, prependFeedStateEntry, saveFeedState } from './feed/state.js';
 import type { Advisory, SelfCheckResult } from './feed/types.js';
+import { CloudRequestError } from './cloud/client.js';
+import { notifyOpenClawRegistrationLink } from './cloud/openclaw-notify.js';
 import {
   installThreatFeedCron,
   validateCronExpression,
@@ -115,7 +119,24 @@ async function main() {
     .action(async (options) => {
       const apiKey = options.key || options.apiKey || process.env.AGENTGUARD_API_KEY;
       if (!apiKey) {
-        throw new Error('Missing API key. Pass --key, --api-key, or set AGENTGUARD_API_KEY.');
+        const config = ensureConfig();
+        if (!isOpenClawAgentConfigured(config)) {
+          throw new Error('Missing API key. Pass --key, --api-key, set AGENTGUARD_API_KEY, or run `agentguard init --agent openclaw` before using Agent JWT registration.');
+        }
+        const registration = await registerAgentCredential({
+          cloudUrl: options.cloud || options.url,
+          reason: 'connect',
+          notifyOpenClaw: true,
+        });
+        console.log(`Registered local AgentGuard agent (${registration.config.agentId}).`);
+        console.log('Open this link to bind AgentGuard Cloud to your email:');
+        console.log(registration.registerUrl);
+        if (registration.openClawNotification.notified) {
+          console.log('Sent the activation link to the last OpenClaw channel.');
+        } else if (registration.openClawNotification.reason) {
+          console.log(`OpenClaw notification skipped: ${registration.openClawNotification.reason}`);
+        }
+        return;
       }
       const config = connectCloud({ apiKey, cloudUrl: options.cloud || options.url });
       const client = new AgentGuardCloudClient(config);
@@ -136,7 +157,7 @@ async function main() {
     .action(() => {
       const config = disconnectCloud();
       console.log('Disconnected from AgentGuard Cloud.');
-      console.log('Removed local Cloud API key, connection timestamp, pending event spool, and cached Cloud policy.');
+      console.log('Removed local Cloud API key, Agent JWT, connection timestamp, pending event spool, and cached Cloud policy.');
       console.log(`Local protection remains active using the built-in policy. Audit log: ${config.auditPath}`);
     });
 
@@ -150,6 +171,9 @@ async function main() {
       console.log(`Protection level: ${config.level}`);
       console.log(`Cloud URL: ${config.cloudUrl || 'not configured'}`);
       console.log(`API key: ${maskApiKey(config.apiKey)}`);
+      console.log(`Agent ID: ${config.agentId || 'not configured'}`);
+      console.log(`Agent JWT: ${config.agentJwt ? 'configured' : 'not configured'}`);
+      console.log(`Agent activation URL: ${config.agentRegisterUrl || 'not configured'}`);
       console.log(`Agent host: ${config.agentHost || 'not configured'}`);
       console.log(`Agent hosts: ${config.agentHosts?.join(', ') || 'not configured'}`);
       console.log(`Policy cache: ${config.policyCachePath}`);
@@ -169,7 +193,7 @@ async function main() {
       const config = ensureConfig();
       const client = new AgentGuardCloudClient(config);
       if (!client.connected) {
-        const message = 'AgentGuard Cloud is not connected. Run `agentguard connect --key <key>` first.';
+        const message = 'AgentGuard Cloud is not connected. Run `agentguard connect` first.';
         if (options.json) {
           console.log(JSON.stringify({ success: false, error: message }, null, 2));
         } else {
@@ -322,8 +346,8 @@ async function main() {
     .option('--cron-run', 'Internal: run from the OpenClaw cron prompt without trying to install cron again')
     .option('--cron-notify-run', 'Internal: run from an OpenClaw cron prompt and print only the notification body or NO_REPLY')
     .action(async (options) => {
-      const config = ensureConfig();
-      const client = new AgentGuardCloudClient(config);
+      let config = ensureConfig();
+      let client = new AgentGuardCloudClient(config);
       const state = loadFeedState();
       const since = options.since as string | undefined;
       const quiet = Boolean(options.quiet);
@@ -333,18 +357,125 @@ async function main() {
         ? validateCronExpression(options.cron as string)
         : undefined;
 
+      let registration: AgentCredentialRegistration | null = null;
+      if (!client.connected) {
+        if (!isOpenClawAgentConfigured(config)) {
+          const message = 'AgentGuard Cloud is not connected. Run `agentguard connect --key <key>` first, or run `agentguard init --agent openclaw` to use Agent JWT registration.';
+          if (cronNotifyRun) {
+            console.log('NO_REPLY');
+          } else if (options.json) {
+            console.log(JSON.stringify({ success: false, error: message }, null, 2));
+          } else {
+            console.error(message);
+          }
+          process.exitCode = 1;
+          return;
+        }
+        try {
+          registration = await registerAgentCredential({
+            cloudUrl: config.cloudUrl,
+            reason: 'subscribe',
+            notifyOpenClaw: resolveCronAgentHost(config) === 'openclaw',
+          });
+          config = registration.config;
+          client = registration.client;
+        } catch (err) {
+          if (cronNotifyRun) {
+            console.log('NO_REPLY');
+            process.exitCode = 0;
+            return;
+          }
+          console.error(`! Could not register AgentGuard agent: ${(err as Error).message}`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      try {
+        await client.subscribeFeed();
+      } catch (err) {
+        if (err instanceof CloudRequestError && err.status === 401) {
+          if (!isOpenClawAgentConfigured(config)) {
+            console.error('! AgentGuard Cloud credential was rejected. Run `agentguard connect --key <key>` again.');
+            process.exitCode = 1;
+            return;
+          }
+          try {
+            registration = await registerAgentCredential({
+              cloudUrl: config.cloudUrl,
+              reason: 'subscribe',
+              notifyOpenClaw: resolveCronAgentHost(config) === 'openclaw',
+              resetExistingJwt: true,
+            });
+            config = registration.config;
+            client = registration.client;
+            await client.subscribeFeed();
+          } catch (retryErr) {
+            if (cronNotifyRun) {
+              console.log('NO_REPLY');
+              process.exitCode = 0;
+              return;
+            }
+            printAgentActivationRequired(registration, retryErr);
+            process.exitCode = 1;
+            return;
+          }
+        } else {
+          if (cronNotifyRun) {
+            console.log('NO_REPLY');
+            process.exitCode = 0;
+            return;
+          }
+          console.error(`! Could not subscribe to AgentGuard Cloud feed: ${(err as Error).message}`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      if (registration && !cronNotifyRun && !quiet && !options.json) {
+        printAgentRegistrationNotice(registration);
+      }
+
       let advisories: Advisory[] | null;
       try {
         advisories = await client.pullAdvisories(since);
       } catch (err) {
-        if (cronNotifyRun) {
-          console.log('NO_REPLY');
-          process.exitCode = 0;
+        if (err instanceof CloudRequestError && err.status === 401) {
+          if (!isOpenClawAgentConfigured(config)) {
+            console.error('! AgentGuard Cloud credential was rejected. Run `agentguard connect --key <key>` again.');
+            process.exitCode = 1;
+            return;
+          }
+          try {
+            registration = await registerAgentCredential({
+              cloudUrl: config.cloudUrl,
+              reason: 'subscribe',
+              notifyOpenClaw: resolveCronAgentHost(config) === 'openclaw',
+              resetExistingJwt: true,
+            });
+            config = registration.config;
+            client = registration.client;
+            advisories = await client.pullAdvisories(since);
+          } catch (retryErr) {
+            if (cronNotifyRun) {
+              console.log('NO_REPLY');
+              process.exitCode = 0;
+              return;
+            }
+            printAgentActivationRequired(registration, retryErr);
+            process.exitCode = 1;
+            return;
+          }
+        } else {
+          if (cronNotifyRun) {
+            console.log('NO_REPLY');
+            process.exitCode = 0;
+            return;
+          }
+          console.error(`! Could not reach AgentGuard Cloud: ${(err as Error).message}`);
+          process.exitCode = 1;
           return;
         }
-        console.error(`! Could not reach AgentGuard Cloud: ${(err as Error).message}`);
-        process.exitCode = 1;
-        return;
       }
       if (advisories === null) {
         // 404 — older Cloud build without the feed endpoint. Not an error.
@@ -535,7 +666,7 @@ async function main() {
 
       const client = new AgentGuardCloudClient(config);
       if (!client.connected) {
-        const message = 'AgentGuard Cloud is not connected. Run `agentguard connect --key <key>` first.';
+        const message = 'AgentGuard Cloud is not connected. Run `agentguard connect` first.';
         if (options.json) {
           console.log(JSON.stringify({ success: false, error: message }, null, 2));
         } else {
@@ -952,6 +1083,81 @@ function runCommandText(command: string, args: string[]): Promise<string> {
       resolvePromise('');
     }
   });
+}
+
+interface AgentCredentialRegistration {
+  config: AgentGuardConfig;
+  client: AgentGuardCloudClient;
+  registerUrl: string;
+  openClawNotification: {
+    notified: boolean;
+    reason?: string;
+  };
+}
+
+async function registerAgentCredential(options: {
+  cloudUrl?: string;
+  reason: 'connect' | 'subscribe' | 'reauth';
+  notifyOpenClaw: boolean;
+  resetExistingJwt?: boolean;
+}): Promise<AgentCredentialRegistration> {
+  if (options.resetExistingJwt) {
+    clearAgentJwt();
+  }
+  const baseConfig = ensureConfig();
+  const cloudUrl = normalizeCloudUrl(options.cloudUrl || baseConfig.cloudUrl || 'https://agentguard.gopluslabs.io');
+  const client = new AgentGuardCloudClient({ ...baseConfig, cloudUrl });
+  const registration = await client.registerAgent({
+    metadata: {
+      agentHost: baseConfig.agentHost,
+      agentHosts: baseConfig.agentHosts,
+      agentVersion: packageVersion,
+      platform: process.platform,
+      arch: process.arch,
+      reason: options.reason,
+    },
+  });
+  const config = connectAgentJwt({
+    agentId: registration.agentId,
+    agentJwt: registration.jwt,
+    agentRegisterUrl: registration.registerUrl,
+    cloudUrl,
+  });
+  const nextClient = new AgentGuardCloudClient(config);
+  const openClawNotification = options.notifyOpenClaw
+    ? await notifyOpenClawRegistrationLink(registration.registerUrl)
+    : { notified: false, reason: 'OpenClaw notification was not requested.' };
+  return {
+    config,
+    client: nextClient,
+    registerUrl: registration.registerUrl,
+    openClawNotification,
+  };
+}
+
+function printAgentRegistrationNotice(registration: AgentCredentialRegistration): void {
+  console.log('AgentGuard Cloud activation is ready:');
+  console.log(registration.registerUrl);
+  if (registration.openClawNotification.notified) {
+    console.log('Sent the activation link to the last OpenClaw channel.');
+  }
+}
+
+function printAgentActivationRequired(
+  registration: AgentCredentialRegistration | null,
+  err: unknown
+): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`! AgentGuard Cloud authorization is not active yet. ${message}`);
+  const registerUrl = registration?.registerUrl || ensureConfig().agentRegisterUrl;
+  if (registerUrl) {
+    console.error('Open this link to bind this agent to your email, then rerun the command:');
+    console.error(registerUrl);
+  }
+}
+
+function isOpenClawAgentConfigured(config: AgentGuardConfig): boolean {
+  return config.agentHost === 'openclaw' || config.agentHosts?.includes('openclaw') === true;
 }
 
 function calculateCompositeScore(dimensions: HealthCheckupReport['dimensions']): number {

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -33,14 +33,16 @@ interface ApiMeta {
 export class AgentGuardCloudClient {
   private readonly cloudUrl: string;
   private readonly apiKey?: string;
+  private readonly agentJwt?: string;
 
-  constructor(config: Pick<AgentGuardConfig, 'cloudUrl' | 'apiKey'>) {
+  constructor(config: Pick<AgentGuardConfig, 'cloudUrl' | 'apiKey' | 'agentJwt'>) {
     this.cloudUrl = normalizeCloudUrl(config.cloudUrl || 'https://agentguard.gopluslabs.io');
     this.apiKey = config.apiKey;
+    this.agentJwt = config.agentJwt;
   }
 
   get connected(): boolean {
-    return Boolean(this.apiKey);
+    return Boolean(this.agentJwt || this.apiKey);
   }
 
   async status(): Promise<{ ok?: boolean; service?: string; status?: string; version?: string; detectors?: number }> {
@@ -48,13 +50,13 @@ export class AgentGuardCloudClient {
   }
 
   async fetchEffectivePolicy(): Promise<EffectiveRuntimePolicy> {
-    this.requireApiKey();
+    this.requireCredential();
     const body = await this.request<EffectiveRuntimePolicy>('/api/v1/policies/effective');
     return body.data;
   }
 
   async evaluateAction(action: RuntimeAction): Promise<RuntimeDecision> {
-    this.requireApiKey();
+    this.requireCredential();
     const body = await this.request<RuntimeDecision>('/api/v1/actions/evaluate', {
       method: 'POST',
       body: JSON.stringify(sanitizeActionRequest(action)),
@@ -63,7 +65,7 @@ export class AgentGuardCloudClient {
   }
 
   async ingestEvents(events: RuntimeAuditEvent[]): Promise<void> {
-    this.requireApiKey();
+    this.requireCredential();
     await this.request('/api/v1/events/ingest', {
       method: 'POST',
       body: JSON.stringify({
@@ -115,7 +117,7 @@ export class AgentGuardCloudClient {
     matches: SelfCheckMatch[],
     options: { elapsedMs?: number; warnings?: string[] } = {}
   ): Promise<void> {
-    this.requireApiKey();
+    this.requireCredential();
     try {
       await this.request('/api/v1/feed/self-check-report', {
         method: 'POST',
@@ -129,6 +131,53 @@ export class AgentGuardCloudClient {
     } catch (err) {
       if (err instanceof CloudRequestError && err.status === 404) {
         return;
+      }
+      throw err;
+    }
+  }
+
+  async registerAgent(options: {
+    email?: string;
+    metadata?: Record<string, unknown>;
+  } = {}): Promise<{ agentId: string; jwt: string; registerUrl: string }> {
+    const body = await this.request<{
+      agentId: string;
+      jwt: string;
+      registerUrl: string;
+    }>('/api/agent/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        ...(options.email ? { email: options.email } : {}),
+        ...(options.metadata ? { metadata: options.metadata } : {}),
+      }),
+    });
+    return body.data;
+  }
+
+  async subscribeFeed(options: {
+    ecosystems?: string[];
+    webhookUrl?: string | null;
+  } = {}): Promise<unknown | null> {
+    this.requireCredential();
+    try {
+      const body = await this.request('/api/v1/feed/subscribe', {
+        method: 'POST',
+        body: JSON.stringify({
+          ecosystems: options.ecosystems ?? [
+            'skill',
+            'plugin',
+            'mcp_server',
+            'supply_chain',
+            'url',
+            'prompt_injection',
+          ],
+          webhookUrl: options.webhookUrl ?? null,
+        }),
+      });
+      return body.data;
+    } catch (err) {
+      if (err instanceof CloudRequestError && err.status === 404) {
+        return null;
       }
       throw err;
     }
@@ -156,7 +205,7 @@ export class AgentGuardCloudClient {
       ...init,
       headers: {
         'content-type': 'application/json',
-        ...(this.apiKey ? { 'x-api-key': this.apiKey } : {}),
+        ...this.authHeaders(),
         ...(init.headers || {}),
       },
       signal: AbortSignal.timeout(5000),
@@ -168,9 +217,19 @@ export class AgentGuardCloudClient {
     return body;
   }
 
-  private requireApiKey(): void {
-    if (!this.apiKey) {
-      throw new Error('AgentGuard Cloud API key is not configured.');
+  private authHeaders(): Record<string, string> {
+    if (this.agentJwt) {
+      return { Authorization: `Bearer ${this.agentJwt}` };
+    }
+    if (this.apiKey) {
+      return { 'x-api-key': this.apiKey };
+    }
+    return {};
+  }
+
+  private requireCredential(): void {
+    if (!this.agentJwt && !this.apiKey) {
+      throw new Error('AgentGuard Cloud credential is not configured.');
     }
   }
 }

--- a/src/cloud/openclaw-notify.ts
+++ b/src/cloud/openclaw-notify.ts
@@ -1,0 +1,93 @@
+import { randomUUID } from 'node:crypto';
+import { openClawGatewayRequest, type OpenClawGatewayOptions } from '../feed/cron.js';
+
+export interface OpenClawRegistrationNotificationResult {
+  notified: boolean;
+  reason?: string;
+}
+
+interface OpenClawSessionRow {
+  key?: string;
+  lastChannel?: string;
+  lastTo?: string;
+  lastAccountId?: string;
+  lastThreadId?: string | number;
+}
+
+export async function notifyOpenClawRegistrationLink(
+  registerUrl: string,
+  gateway: OpenClawGatewayOptions = {}
+): Promise<OpenClawRegistrationNotificationResult> {
+  try {
+    const listed = await openClawGatewayRequest(
+      'sessions.list',
+      { limit: 20, configuredAgentsOnly: false },
+      gateway
+    );
+    const session = extractOpenClawSessionRows(listed).find(
+      (row) => typeof row.lastChannel === 'string' && row.lastChannel.trim() &&
+        typeof row.lastTo === 'string' && row.lastTo.trim()
+    );
+    if (!session?.lastChannel || !session.lastTo) {
+      return { notified: false, reason: 'No OpenClaw session with a deliverable last channel was found.' };
+    }
+
+    await openClawGatewayRequest(
+      'send',
+      {
+        channel: session.lastChannel,
+        to: session.lastTo,
+        ...(session.lastAccountId ? { accountId: session.lastAccountId } : {}),
+        ...(session.lastThreadId ? { threadId: String(session.lastThreadId) } : {}),
+        ...(session.key ? { sessionKey: session.key } : {}),
+        message: [
+          'AgentGuard Cloud activation is ready.',
+          '',
+          'Open this link to bind this agent to your account:',
+          registerUrl,
+        ].join('\n'),
+        idempotencyKey: `agentguard-register-${randomUUID()}`,
+      },
+      gateway
+    );
+    return { notified: true };
+  } catch (err) {
+    return {
+      notified: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function extractOpenClawSessionRows(value: unknown): OpenClawSessionRow[] {
+  if (Array.isArray(value)) return value.flatMap(extractOpenClawSessionRows);
+  if (!value || typeof value !== 'object') return [];
+  const obj = value as {
+    sessions?: unknown;
+    rows?: unknown;
+    result?: unknown;
+    data?: unknown;
+    key?: unknown;
+    lastChannel?: unknown;
+    lastTo?: unknown;
+    lastAccountId?: unknown;
+    lastThreadId?: unknown;
+  };
+  if (typeof obj.lastChannel === 'string' || typeof obj.lastTo === 'string') {
+    return [{
+      key: typeof obj.key === 'string' ? obj.key : undefined,
+      lastChannel: typeof obj.lastChannel === 'string' ? obj.lastChannel : undefined,
+      lastTo: typeof obj.lastTo === 'string' ? obj.lastTo : undefined,
+      lastAccountId: typeof obj.lastAccountId === 'string' ? obj.lastAccountId : undefined,
+      lastThreadId: typeof obj.lastThreadId === 'string' || typeof obj.lastThreadId === 'number'
+        ? obj.lastThreadId
+        : undefined,
+    }];
+  }
+  return [
+    ...extractOpenClawSessionRows(obj.sessions),
+    ...extractOpenClawSessionRows(obj.rows),
+    ...extractOpenClawSessionRows(obj.result),
+    ...extractOpenClawSessionRows(obj.data),
+  ];
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,6 +110,10 @@ export function connectCloud(options: { apiKey: string; cloudUrl?: string }): Ag
     apiKey: options.apiKey,
     connectedAt: new Date().toISOString(),
   };
+  delete next.agentId;
+  delete next.agentJwt;
+  delete next.agentRegisterUrl;
+  delete next.agentRegisteredAt;
   saveConfig(next);
   return next;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,10 @@ export interface AgentGuardConfig {
   agentHosts?: AgentGuardAgentHost[];
   cloudUrl?: string;
   apiKey?: string;
+  agentId?: string;
+  agentJwt?: string;
+  agentRegisterUrl?: string;
+  agentRegisteredAt?: string;
   connectedAt?: string;
   policyCachePath: string;
   auditPath: string;
@@ -110,10 +114,52 @@ export function connectCloud(options: { apiKey: string; cloudUrl?: string }): Ag
   return next;
 }
 
+export function connectAgentJwt(options: {
+  agentId: string;
+  agentJwt: string;
+  agentRegisterUrl?: string;
+  cloudUrl?: string;
+}): AgentGuardConfig {
+  const current = ensureConfig();
+  const agentId = options.agentId.trim();
+  const agentJwt = options.agentJwt.trim();
+  if (!agentId) {
+    throw new Error('Invalid Agent registration response: missing agentId.');
+  }
+  if (!agentJwt) {
+    throw new Error('Invalid Agent registration response: missing jwt.');
+  }
+  const next: AgentGuardConfig = {
+    ...current,
+    cloudUrl: normalizeCloudUrl(options.cloudUrl || current.cloudUrl || DEFAULT_CLOUD_URL),
+    agentId,
+    agentJwt,
+    agentRegisterUrl: options.agentRegisterUrl?.trim() || current.agentRegisterUrl,
+    agentRegisteredAt: new Date().toISOString(),
+    connectedAt: new Date().toISOString(),
+  };
+  saveConfig(next);
+  return next;
+}
+
+export function clearAgentJwt(config: AgentGuardConfig = ensureConfig()): AgentGuardConfig {
+  const next: AgentGuardConfig = { ...config };
+  delete next.agentId;
+  delete next.agentJwt;
+  delete next.agentRegisterUrl;
+  delete next.agentRegisteredAt;
+  saveConfig(next);
+  return next;
+}
+
 export function disconnectCloud(): AgentGuardConfig {
   const current = ensureConfig();
   const next: AgentGuardConfig = { ...current };
   delete next.apiKey;
+  delete next.agentId;
+  delete next.agentJwt;
+  delete next.agentRegisterUrl;
+  delete next.agentRegisteredAt;
   delete next.connectedAt;
   rmSync(current.eventSpoolPath, { force: true });
   rmSync(current.policyCachePath, { force: true });

--- a/src/feed/cron.ts
+++ b/src/feed/cron.ts
@@ -500,6 +500,23 @@ function shellQuote(value: string): string {
 function openClawCronMessage(quiet: boolean): string {
   const mode = quiet ? 'quiet' : 'manual';
   const command = threatFeedCommand(quiet, { notifyRun: true });
+  if (!quiet) {
+    return [
+      `Mode: ${mode}.`,
+      `Command: \`${command}\`.`,
+      `Run exactly the command above.`,
+      '',
+      'Rules:',
+      '- If the command fails, prints no stdout, or prints only `NO_REPLY`, output `NO_REPLY`.',
+      '- If the command prints threat-feed advisories, read the full output, including any remediation guidance.',
+      '- Respond in the same language as the user would naturally use for this chat.',
+      '- Summarize the new threat(s), identify the likely local impact, and give concise manual response steps.',
+      '- Preserve advisory IDs and severity labels.',
+      '- Do not claim a local match was found unless the command output explicitly says so.',
+      '',
+      'Follow these rules exactly.',
+    ].join('\n');
+  }
   return [
     `Mode: ${mode}.`,
     `Command: \`${command}\`.`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,8 @@ export {
   loadConfig as loadAgentGuardConfig,
   saveConfig as saveAgentGuardConfig,
   connectCloud,
+  connectAgentJwt,
+  clearAgentJwt,
   disconnectCloud,
   getAgentGuardPaths,
   type AgentGuardConfig,

--- a/src/runtime/protect.ts
+++ b/src/runtime/protect.ts
@@ -36,14 +36,14 @@ export async function protectAction(options: ProtectOptions): Promise<ProtectRes
   let decision: RuntimeDecision;
   let policySource: ProtectResult['policySource'];
   if (options.decisionMode === 'cloud' && client.connected) {
-    decision = await client.evaluateAction(action);
+    decision = normalizeRuntimeDecision(await client.evaluateAction(action));
     policySource = 'cloud-decision';
   } else {
     const { policy, source } = await resolveRuntimePolicy({
       cachePath: options.config.policyCachePath,
       fetchPolicy: client.connected ? () => client.fetchEffectivePolicy() : undefined,
     });
-    decision = await evaluateLocalAction(policy, action);
+    decision = normalizeRuntimeDecision(await evaluateLocalAction(policy, action));
     policySource = source;
   }
 
@@ -77,6 +77,14 @@ export async function protectAction(options: ProtectOptions): Promise<ProtectRes
   }
 
   return { decision, event, approvalChannel, policySource };
+}
+
+function normalizeRuntimeDecision(decision: RuntimeDecision): RuntimeDecision {
+  const rawDecision = (decision as unknown as { decision?: string }).decision;
+  if (rawDecision === 'require_approve') {
+    return { ...decision, decision: 'require_approval' };
+  }
+  return decision;
 }
 
 export function formatProtectResult(result: ProtectResult, json = false): string {

--- a/src/tests/cli-checkup.test.ts
+++ b/src/tests/cli-checkup.test.ts
@@ -107,6 +107,6 @@ describe('CLI checkup command modes', () => {
     assert.equal(result.stderr, '');
     const parsed = JSON.parse(result.stdout) as { success: boolean; error: string };
     assert.equal(parsed.success, false);
-    assert.match(parsed.error, /agentguard connect --key <key>/);
+    assert.match(parsed.error, /agentguard connect/);
   });
 });

--- a/src/tests/cli-connect.test.ts
+++ b/src/tests/cli-connect.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const projectRoot = resolve(__dirname, '..', '..');
+const CLI_PATH = join(projectRoot, 'dist', 'cli.js');
+
+function runCli(args: string[], home: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolvePromise) => {
+    const child = spawn('node', [CLI_PATH, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        AGENTGUARD_HOME: home,
+        HOME: home,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d: Buffer) => (stdout += d.toString()));
+    child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
+    child.on('close', (code) => {
+      resolvePromise({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+describe('CLI connect Agent JWT mode', () => {
+  it('registers a local agent and persists the Agent JWT when no API key is supplied', async () => {
+    const requests: Array<{ url?: string; method?: string; body?: unknown }> = [];
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => {
+        requests.push({ url: req.url, method: req.method, body: body ? JSON.parse(body) : undefined });
+        if (req.method === 'POST' && req.url === '/api/agent/register') {
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({
+            success: true,
+            data: {
+              agentId: 'agt_cli_test',
+              jwt: 'agent.jwt.cli-test',
+              registerUrl: 'https://agentguard.example/activate?token=cli-test',
+            },
+          }));
+          return;
+        }
+        res.statusCode = 404;
+        res.end(JSON.stringify({ success: false }));
+      });
+    });
+    await new Promise<void>((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise));
+    try {
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      const cloudUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+      const home = mkdtempSync(join(tmpdir(), 'ag-cli-connect-'));
+      writeFileSync(join(home, 'config.json'), JSON.stringify({
+        version: 1,
+        level: 'balanced',
+        cloudUrl,
+        agentHost: 'openclaw',
+        agentHosts: ['openclaw'],
+        policyCachePath: join(home, 'policy-cache.json'),
+        auditPath: join(home, 'audit.jsonl'),
+        eventSpoolPath: join(home, 'events-spool.jsonl'),
+      }));
+
+      const result = await runCli(['connect', '--url', cloudUrl], home);
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stderr, '');
+      assert.match(result.stdout, /Registered local AgentGuard agent \(agt_cli_test\)/);
+      assert.match(result.stdout, /https:\/\/agentguard\.example\/activate\?token=cli-test/);
+      assert.equal(requests[0].url, '/api/agent/register');
+      const config = JSON.parse(readFileSync(join(home, 'config.json'), 'utf8')) as {
+        agentId?: string;
+        agentJwt?: string;
+        agentRegisterUrl?: string;
+        cloudUrl?: string;
+      };
+      assert.equal(config.cloudUrl, cloudUrl);
+      assert.equal(config.agentId, 'agt_cli_test');
+      assert.equal(config.agentJwt, 'agent.jwt.cli-test');
+      assert.equal(config.agentRegisterUrl, 'https://agentguard.example/activate?token=cli-test');
+    } finally {
+      await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+    }
+  });
+
+  it('does not use Agent JWT registration before OpenClaw has been initialized', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-connect-no-openclaw-'));
+
+    const result = await runCli(['connect', '--url', 'https://agentguard.example'], home);
+
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /init --agent openclaw/);
+  });
+});

--- a/src/tests/cli-connect.test.ts
+++ b/src/tests/cli-connect.test.ts
@@ -6,6 +6,7 @@ import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { getDefaultEffectiveRuntimePolicy } from '../runtime/policy.js';
 
 const projectRoot = resolve(__dirname, '..', '..');
 const CLI_PATH = join(projectRoot, 'dist', 'cli.js');
@@ -90,6 +91,124 @@ describe('CLI connect Agent JWT mode', () => {
       assert.equal(config.agentId, 'agt_cli_test');
       assert.equal(config.agentJwt, 'agent.jwt.cli-test');
       assert.equal(config.agentRegisterUrl, 'https://agentguard.example/activate?token=cli-test');
+    } finally {
+      await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+    }
+  });
+
+  it('reuses an active saved Agent JWT instead of registering again', async () => {
+    const requests: Array<{ url?: string; method?: string; authorization?: string }> = [];
+    const server = http.createServer((req, res) => {
+      requests.push({ url: req.url, method: req.method, authorization: req.headers.authorization });
+      if (req.method === 'GET' && req.url === '/api/v1/policies/effective') {
+        assert.equal(req.headers.authorization, 'Bearer agent.jwt.active');
+        const policy = getDefaultEffectiveRuntimePolicy();
+        policy.policyVersion = 'active-jwt-policy';
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ success: true, data: policy }));
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/api/agent/register') {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ success: false }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ success: false }));
+    });
+    await new Promise<void>((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise));
+    try {
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      const cloudUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+      const home = mkdtempSync(join(tmpdir(), 'ag-cli-connect-existing-'));
+      writeFileSync(join(home, 'config.json'), JSON.stringify({
+        version: 1,
+        level: 'balanced',
+        cloudUrl,
+        agentHost: 'openclaw',
+        agentHosts: ['openclaw'],
+        agentId: 'agt_existing',
+        agentJwt: 'agent.jwt.active',
+        agentRegisterUrl: 'https://agentguard.example/activate?token=old',
+        policyCachePath: join(home, 'policy-cache.json'),
+        auditPath: join(home, 'audit.jsonl'),
+        eventSpoolPath: join(home, 'events-spool.jsonl'),
+      }));
+
+      const result = await runCli(['connect', '--url', cloudUrl], home);
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stderr, '');
+      assert.match(result.stdout, /Agent JWT is active for local agent agt_existing/);
+      assert.equal(requests.filter((request) => request.url === '/api/agent/register').length, 0);
+      const config = JSON.parse(readFileSync(join(home, 'config.json'), 'utf8')) as {
+        agentId?: string;
+        agentJwt?: string;
+      };
+      assert.equal(config.agentId, 'agt_existing');
+      assert.equal(config.agentJwt, 'agent.jwt.active');
+    } finally {
+      await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+    }
+  });
+
+  it('re-registers a saved Agent JWT only after Cloud rejects it with 401', async () => {
+    const requests: Array<{ url?: string; method?: string; authorization?: string }> = [];
+    const server = http.createServer((req, res) => {
+      requests.push({ url: req.url, method: req.method, authorization: req.headers.authorization });
+      if (req.method === 'GET' && req.url === '/api/v1/policies/effective') {
+        res.statusCode = 401;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ success: false, error: { message: 'inactive agent jwt' } }));
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/api/agent/register') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          success: true,
+          data: {
+            agentId: 'agt_reissued',
+            jwt: 'agent.jwt.reissued',
+            registerUrl: 'https://agentguard.example/activate?token=reissued',
+          },
+        }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ success: false }));
+    });
+    await new Promise<void>((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise));
+    try {
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      const cloudUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+      const home = mkdtempSync(join(tmpdir(), 'ag-cli-connect-reauth-'));
+      writeFileSync(join(home, 'config.json'), JSON.stringify({
+        version: 1,
+        level: 'balanced',
+        cloudUrl,
+        agentHost: 'openclaw',
+        agentHosts: ['openclaw'],
+        agentId: 'agt_old',
+        agentJwt: 'agent.jwt.old',
+        policyCachePath: join(home, 'policy-cache.json'),
+        auditPath: join(home, 'audit.jsonl'),
+        eventSpoolPath: join(home, 'events-spool.jsonl'),
+      }));
+
+      const result = await runCli(['connect', '--url', cloudUrl], home);
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stderr, '');
+      assert.match(result.stdout, /Registered local AgentGuard agent \(agt_reissued\)/);
+      assert.equal(requests.filter((request) => request.url === '/api/agent/register').length, 1);
+      const config = JSON.parse(readFileSync(join(home, 'config.json'), 'utf8')) as {
+        agentId?: string;
+        agentJwt?: string;
+      };
+      assert.equal(config.agentId, 'agt_reissued');
+      assert.equal(config.agentJwt, 'agent.jwt.reissued');
     } finally {
       await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
     }

--- a/src/tests/cli-policy.test.ts
+++ b/src/tests/cli-policy.test.ts
@@ -124,4 +124,83 @@ describe('policy CLI', () => {
       });
     }
   });
+
+  it('re-registers an OpenClaw Agent JWT on policy pull 401 and retries once', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-policy-reauth-'));
+    const policy = getDefaultEffectiveRuntimePolicy();
+    policy.policyVersion = 'runtime-agent-jwt-retry';
+
+    const requests: Array<{ url?: string; method?: string; authorization?: string }> = [];
+    const server = createServer((req, res) => {
+      requests.push({ url: req.url, method: req.method, authorization: req.headers.authorization });
+      if (req.url === '/api/v1/policies/effective' && req.headers.authorization === 'Bearer agent.jwt.old') {
+        res.writeHead(401, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ success: false, error: { message: 'stale jwt' } }));
+        return;
+      }
+      if (req.url === '/api/agent/register' && req.method === 'POST') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          success: true,
+          data: {
+            agentId: 'agt_policy_retry',
+            jwt: 'agent.jwt.new',
+            registerUrl: 'https://agentguard.example/activate?token=policy',
+          },
+        }));
+        return;
+      }
+      if (req.url === '/api/v1/policies/effective' && req.headers.authorization === 'Bearer agent.jwt.new') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ success: true, data: policy }));
+        return;
+      }
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ success: false, error: { message: 'not found' } }));
+    });
+
+    await new Promise<void>((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise));
+    try {
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      const cloudUrl = `http://127.0.0.1:${address.port}`;
+      const cachePath = join(home, 'policy-cache.json');
+      writeFileSync(join(home, 'config.json'), JSON.stringify({
+        version: 1,
+        level: 'balanced',
+        cloudUrl,
+        agentHost: 'openclaw',
+        agentHosts: ['openclaw'],
+        agentId: 'agt_policy_old',
+        agentJwt: 'agent.jwt.old',
+        policyCachePath: cachePath,
+        auditPath: join(home, 'audit.jsonl'),
+        eventSpoolPath: join(home, 'events-spool.jsonl'),
+      }));
+
+      const cliPath = resolve('dist/cli.js');
+      const { stdout } = await execFileAsync(process.execPath, [cliPath, 'policy', 'pull', '--json'], {
+        env: { ...process.env, AGENTGUARD_HOME: home },
+      });
+
+      const result = JSON.parse(stdout) as { success: boolean; policyVersion: string };
+      assert.equal(result.success, true);
+      assert.equal(result.policyVersion, 'runtime-agent-jwt-retry');
+      assert.deepEqual(requests.map((request) => request.url), [
+        '/api/v1/policies/effective',
+        '/api/agent/register',
+        '/api/v1/policies/effective',
+      ]);
+      const savedConfig = JSON.parse(readFileSync(join(home, 'config.json'), 'utf8')) as {
+        agentId?: string;
+        agentJwt?: string;
+      };
+      assert.equal(savedConfig.agentId, 'agt_policy_retry');
+      assert.equal(savedConfig.agentJwt, 'agent.jwt.new');
+    } finally {
+      await new Promise<void>((resolvePromise, reject) => {
+        server.close((err) => err ? reject(err) : resolvePromise());
+      });
+    }
+  });
 });

--- a/src/tests/cli-subscribe.test.ts
+++ b/src/tests/cli-subscribe.test.ts
@@ -13,6 +13,10 @@ const CLI_PATH = join(projectRoot, 'dist', 'cli.js');
 
 function runCli(args: string[], home: string, cloudUrl: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   writeConfig(home, cloudUrl);
+  return runCliNoConfigWrite(args, home);
+}
+
+function runCliNoConfigWrite(args: string[], home: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolvePromise) => {
     const child = spawn('node', [CLI_PATH, ...args], {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -202,5 +206,78 @@ describe('CLI subscribe command modes', () => {
       assert.doesNotMatch(result.stdout, /Self-check found/);
       assert.equal(reports.length, 1);
     });
+  });
+
+  it('re-registers the local agent and retries once when Agent JWT auth returns 401', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-subscribe-reauth-'));
+    const authHeaders: Array<string | undefined> = [];
+    const server = http.createServer((req, res) => {
+      if (req.method === 'POST' && req.url === '/api/agent/register') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          success: true,
+          data: {
+            agentId: 'agt_new_subscribe',
+            jwt: 'agent.jwt.new',
+            registerUrl: 'https://agentguard.example/activate?token=new-subscribe',
+          },
+        }));
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/api/v1/feed/subscribe') {
+        authHeaders.push(req.headers.authorization);
+        res.setHeader('content-type', 'application/json');
+        if (req.headers.authorization === 'Bearer agent.jwt.old') {
+          res.statusCode = 401;
+          res.end(JSON.stringify({ success: false, error: { message: 'expired agent jwt' } }));
+          return;
+        }
+        res.end(JSON.stringify({ success: true, data: { id: 'sub_test', status: 'active' } }));
+        return;
+      }
+      if (req.method === 'GET' && req.url?.startsWith('/api/v1/feed/advisories')) {
+        authHeaders.push(req.headers.authorization);
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ success: true, data: { advisories: [] } }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ success: false }));
+    });
+    await new Promise<void>((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise));
+    try {
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      const cloudUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+      mkdirSync(home, { recursive: true });
+      writeFileSync(join(home, 'config.json'), JSON.stringify({
+        version: 1,
+        level: 'balanced',
+        cloudUrl,
+        agentHost: 'openclaw',
+        agentHosts: ['openclaw'],
+        agentId: 'agt_old_subscribe',
+        agentJwt: 'agent.jwt.old',
+        policyCachePath: join(home, 'policy-cache.json'),
+        auditPath: join(home, 'audit.jsonl'),
+        eventSpoolPath: join(home, 'events-spool.jsonl'),
+      }));
+
+      const result = await runCliNoConfigWrite(['subscribe', '--json'], home);
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stderr, '');
+      assert.deepEqual(authHeaders, ['Bearer agent.jwt.old', 'Bearer agent.jwt.new', 'Bearer agent.jwt.new']);
+      const config = JSON.parse(readFileSync(join(home, 'config.json'), 'utf8')) as {
+        agentId?: string;
+        agentJwt?: string;
+        agentRegisterUrl?: string;
+      };
+      assert.equal(config.agentId, 'agt_new_subscribe');
+      assert.equal(config.agentJwt, 'agent.jwt.new');
+      assert.equal(config.agentRegisterUrl, 'https://agentguard.example/activate?token=new-subscribe');
+    } finally {
+      await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+    }
   });
 });

--- a/src/tests/cli-subscribe.test.ts
+++ b/src/tests/cli-subscribe.test.ts
@@ -97,6 +97,10 @@ const advisory: Advisory = {
   detailsMd: 'Demo advisory',
   affected: [{ namePattern: 'malicious-*' }],
   publishedAt: '2026-05-20T00:00:00.000Z',
+  selfCheck: {
+    matchers: [],
+    remediationMd: 'Quarantine the malicious demo skill and rotate any exposed API keys.',
+  },
 };
 
 describe('CLI subscribe command modes', () => {
@@ -109,8 +113,12 @@ describe('CLI subscribe command modes', () => {
 
       assert.equal(result.exitCode, 0);
       assert.equal(result.stderr, '');
-      assert.match(result.stdout, /New threat-feed advisories found/);
+      assert.match(result.stdout, /Pulled 1 advisory record\(s\); 1 new\./);
+      assert.match(result.stdout, /AgentGuard found new threat-feed advisories that need manual review:/);
       assert.match(result.stdout, /AGS-2026-subscribe/);
+      assert.match(result.stdout, /Remediation guidance:/);
+      assert.match(result.stdout, /Quarantine the malicious demo skill/);
+      assert.doesNotMatch(result.stdout, /agentguard subscribe --quiet/);
       assert.doesNotMatch(result.stdout, /Self-check found/);
       assert.equal(reports.length, 0);
     });
@@ -161,6 +169,9 @@ describe('CLI subscribe command modes', () => {
       assert.equal(result.stderr, '');
       assert.match(result.stdout, /^AgentGuard found new threat-feed advisories/m);
       assert.match(result.stdout, /AGS-2026-subscribe/);
+      assert.match(result.stdout, /Remediation guidance:/);
+      assert.match(result.stdout, /Quarantine the malicious demo skill/);
+      assert.doesNotMatch(result.stdout, /agentguard subscribe --quiet/);
       assert.doesNotMatch(result.stdout, /Pulled \d+ advisory/);
     });
   });

--- a/src/tests/feed-cloud.test.ts
+++ b/src/tests/feed-cloud.test.ts
@@ -19,7 +19,7 @@ function startServer(handler: Handler): Promise<{ url: string; server: Server }>
 describe('cloud client — feed methods', () => {
   let baseUrl: string;
   let server: Server;
-  let lastRequest: { url: string; method: string; body?: unknown } | null = null;
+  let lastRequest: { url: string; method: string; headers: Record<string, string | string[] | undefined>; body?: unknown } | null = null;
   let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
 
   before(async () => {
@@ -27,7 +27,7 @@ describe('cloud client — feed methods', () => {
       const chunks: Buffer[] = [];
       for await (const chunk of req) chunks.push(chunk as Buffer);
       const raw = Buffer.concat(chunks).toString('utf8');
-      lastRequest = { url: req.url, method: req.method, body: raw ? JSON.parse(raw) : undefined };
+      lastRequest = { url: req.url, method: req.method, headers: req.headers, body: raw ? JSON.parse(raw) : undefined };
       res.statusCode = nextResponse.status;
       res.setHeader('content-type', 'application/json');
       res.end(JSON.stringify(nextResponse.body));
@@ -82,6 +82,52 @@ describe('cloud client — feed methods', () => {
     assert.equal(result?.length, 1);
     assert.equal(result?.[0].id, 'AGS-2026-1');
     assert.match(lastRequest!.url, /\/api\/v1\/feed\/advisories\?since=/);
+    assert.equal(lastRequest!.headers['x-api-key'], 'ag_live_x');
+  });
+
+  it('uses Agent JWT bearer auth before legacy API keys', async () => {
+    nextResponse = {
+      status: 200,
+      body: {
+        success: true,
+        data: {
+          advisories: [],
+        },
+      },
+    };
+    const client = new AgentGuardCloudClient({
+      cloudUrl: baseUrl,
+      apiKey: 'ag_live_x',
+      agentJwt: 'agent.jwt.test',
+    });
+    const result = await client.pullAdvisories();
+    assert.deepEqual(result, []);
+    assert.equal(lastRequest!.headers.authorization, 'Bearer agent.jwt.test');
+    assert.equal(lastRequest!.headers['x-api-key'], undefined);
+  });
+
+  it('registerAgent POSTs metadata and returns the activation payload', async () => {
+    nextResponse = {
+      status: 200,
+      body: {
+        success: true,
+        data: {
+          agentId: 'agt_test',
+          jwt: 'agent.jwt.created',
+          registerUrl: 'https://agentguard.example/activate?token=test',
+        },
+      },
+    };
+    const client = new AgentGuardCloudClient({ cloudUrl: baseUrl });
+    const result = await client.registerAgent({ metadata: { agentHost: 'openclaw' } });
+    assert.equal(lastRequest!.method, 'POST');
+    assert.match(lastRequest!.url, /\/api\/agent\/register$/);
+    assert.deepEqual(lastRequest!.body, { metadata: { agentHost: 'openclaw' } });
+    assert.deepEqual(result, {
+      agentId: 'agt_test',
+      jwt: 'agent.jwt.created',
+      registerUrl: 'https://agentguard.example/activate?token=test',
+    });
   });
 
   it('pullAdvisories returns null on 404 (older Cloud)', async () => {

--- a/src/tests/feed-cron.test.ts
+++ b/src/tests/feed-cron.test.ts
@@ -116,6 +116,8 @@ describe('feed/cron', () => {
     assert.match(job.payload.message, /Mode: manual/);
     assert.match(job.payload.message, /Command: `agentguard subscribe --cron-notify-run`/);
     assert.match(job.payload.message, /agentguard subscribe --cron-notify-run/);
+    assert.match(job.payload.message, /remediation guidance/);
+    assert.match(job.payload.message, /manual response steps/);
     assert.match(job.payload.message, /NO_REPLY/);
   });
 
@@ -343,6 +345,8 @@ describe('feed/cron', () => {
     assert.deepEqual(job.delivery, { mode: 'announce', channel: 'last' });
     assert.equal('agentguard' in job.payload, false);
     assert.match(job.payload.message, /Command: `agentguard subscribe --cron-notify-run`/);
+    assert.match(job.payload.message, /remediation guidance/);
+    assert.match(job.payload.message, /manual response steps/);
   });
 
   it('auto-installs native Hermes cron jobs for Hermes agents', async () => {

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -446,6 +446,46 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
     assert.ok(result?.requireApproval?.description?.includes('Protected path'));
   });
 
+  it('should normalize require_approve runtime decisions before asking in OpenClaw', async () => {
+    ctx = createTestContext();
+    const { api, handlers } = createMockApi();
+    registerOpenClawPlugin(api as never, {
+      skipAutoScan: true,
+      registry: ctx.agentguard.registry as never,
+      protectAction: async () => ({
+        policySource: 'cloud-decision',
+        approvalChannel: 'agent',
+        event: {} as never,
+        decision: {
+          actionId: 'act_approval_alias',
+          decision: 'require_approve' as never,
+          riskScore: 75,
+          riskLevel: 'high',
+          policyVersion: 'cloud-test',
+          reasons: [
+            {
+              code: 'SECRET_ACCESS',
+              severity: 'high',
+              title: 'Protected path',
+              description: 'Protected path access requires approval.',
+            },
+          ],
+        },
+      }),
+    });
+
+    const result = await handlers['before_tool_call']({
+      toolName: 'Read',
+      params: { path: '/workspace/.env' },
+    }) as {
+      requireApproval?: { title?: string; description?: string; severity?: string; timeoutBehavior?: string };
+    } | undefined;
+
+    assert.equal(result?.requireApproval?.title, 'AgentGuard approval required');
+    assert.equal(result?.requireApproval?.severity, 'critical');
+    assert.ok(result?.requireApproval?.description?.includes('requires approval'));
+  });
+
   it('should return { block: true } for rm -rf /', async () => {
     ctx = createTestContext();
     const { api, handlers } = createMockApi();

--- a/src/tests/runtime-cloud.test.ts
+++ b/src/tests/runtime-cloud.test.ts
@@ -9,7 +9,7 @@ import { redactText } from '../runtime/redaction.js';
 import { flushEventSpool, spoolEvent } from '../runtime/audit.js';
 import { exitCodeForDecision, formatProtectResult, protectAction } from '../runtime/protect.js';
 import type { ProtectResult } from '../runtime/protect.js';
-import { connectCloud, disconnectCloud, getAgentGuardPaths } from '../config.js';
+import { connectAgentJwt, connectCloud, disconnectCloud, getAgentGuardPaths } from '../config.js';
 import { AgentGuardCloudClient } from '../cloud/client.js';
 import type { AgentGuardConfig } from '../config.js';
 import type { RuntimeAuditEvent } from '../runtime/types.js';
@@ -69,6 +69,12 @@ describe('Runtime Cloud bridge', () => {
         apiKey: 'ag_live_test_key_123456',
         cloudUrl: 'https://agentguard.example',
       });
+      connectAgentJwt({
+        agentId: 'agt_disconnect_test',
+        agentJwt: 'agent.jwt.disconnect',
+        agentRegisterUrl: 'https://agentguard.example/activate?token=test',
+        cloudUrl: 'https://agentguard.example',
+      });
       writeFileSync(config.eventSpoolPath, `${JSON.stringify(sampleEvent())}\n`);
       writeFileSync(config.policyCachePath, JSON.stringify(getDefaultEffectiveRuntimePolicy()));
       writeFileSync(config.auditPath, `${JSON.stringify(sampleEvent())}\n`);
@@ -77,9 +83,15 @@ describe('Runtime Cloud bridge', () => {
       const saved = JSON.parse(readFileSync(getAgentGuardPaths().configPath, 'utf8')) as AgentGuardConfig;
 
       assert.equal(disconnected.apiKey, undefined);
+      assert.equal(disconnected.agentId, undefined);
+      assert.equal(disconnected.agentJwt, undefined);
+      assert.equal(disconnected.agentRegisterUrl, undefined);
       assert.equal(disconnected.connectedAt, undefined);
       assert.equal(disconnected.cloudUrl, 'https://agentguard.example');
       assert.equal(saved.apiKey, undefined);
+      assert.equal(saved.agentId, undefined);
+      assert.equal(saved.agentJwt, undefined);
+      assert.equal(saved.agentRegisterUrl, undefined);
       assert.equal(saved.connectedAt, undefined);
       assert.equal(saved.cloudUrl, 'https://agentguard.example');
       assert.equal(existsSync(config.eventSpoolPath), false);

--- a/src/tests/runtime-cloud.test.ts
+++ b/src/tests/runtime-cloud.test.ts
@@ -103,6 +103,33 @@ describe('Runtime Cloud bridge', () => {
     }
   });
 
+  it('clears Agent JWT credentials when connecting with an explicit API key', () => {
+    const previousHome = process.env.AGENTGUARD_HOME;
+    process.env.AGENTGUARD_HOME = mkdtempSync(join(tmpdir(), 'agentguard-connect-key-'));
+    try {
+      connectAgentJwt({
+        agentId: 'agt_key_shadow_test',
+        agentJwt: 'agent.jwt.shadow',
+        agentRegisterUrl: 'https://agentguard.example/activate?token=shadow',
+        cloudUrl: 'https://agentguard.example',
+      });
+
+      const config = connectCloud({
+        apiKey: 'ag_live_test_key_123456',
+        cloudUrl: 'https://agentguard.example',
+      });
+
+      assert.equal(config.apiKey, 'ag_live_test_key_123456');
+      assert.equal(config.agentId, undefined);
+      assert.equal(config.agentJwt, undefined);
+      assert.equal(config.agentRegisterUrl, undefined);
+      assert.equal(config.agentRegisteredAt, undefined);
+    } finally {
+      if (previousHome === undefined) delete process.env.AGENTGUARD_HOME;
+      else process.env.AGENTGUARD_HOME = previousHome;
+    }
+  });
+
   it('evaluates local action with cached Cloud policy shape', async () => {
     const policy = getDefaultEffectiveRuntimePolicy();
     policy.policyVersion = 'runtime-test';


### PR DESCRIPTION
## Summary

- Add Agent JWT registration flow for OpenClaw-backed AgentGuard installs, including activation URL persistence and OpenClaw channel notifications.
- Allow Cloud requests to authenticate with Agent JWT bearer tokens while preserving API key support.
- Add feed subscription registration via `/api/v1/feed/subscribe` and retry Agent JWT registration on 401 responses.
- Improve manual threat-feed notifications with remediation guidance and clearer OpenClaw cron instructions.
- Normalize Cloud/runtime `require_approve` decisions to `require_approval` for OpenClaw and local enforcement compatibility.
- Update changelog with an Unreleased section.


## Type

- [x] Bug fix
- [x] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [x] `npm run build` passes
- [x] `npm test` passes (32 tests)
- [ ] Manually tested the change

## Related Issues

Closes #
