### PR TITLE
Fix subscribe cron behavior and runtime false-positive reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Supported agent CLI commands such as `openclaw`, `qclaw`, `hermes`, `codex`, and `claude` are now treated like AgentGuard self-commands so normal agent management commands are not audited, reported, or blocked by AgentGuard hooks while compound shell commands remain protected.
+- Empty safe runtime decisions (`riskScore: 0`, `riskLevel: safe`, and no reasons) no longer trigger local interception or Cloud event sync.
 
 ## [1.1.20] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- `agentguard subscribe` cron internals (`--cron-run` and `--cron-notify-run`) now only pull feed advisories instead of re-subscribing on every scheduled run, preserving Cloud-side unsubscribe choices.
+
+### Fixed
+- Supported agent CLI commands such as `openclaw`, `qclaw`, `hermes`, `codex`, and `claude` are now treated like AgentGuard self-commands so normal agent management commands are not audited, reported, or blocked by AgentGuard hooks while compound shell commands remain protected.
+
 ## [1.1.20] - 2026-05-27
 
 ### Changed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -447,49 +447,36 @@ async function main() {
         }
       }
 
-      try {
-        await client.subscribeFeed();
-      } catch (err) {
-        if (err instanceof CloudRequestError && err.status === 401) {
-          if (cronInternalRun) {
-            await printSubscribeConnectRequired(options, cronRunSendsToOpenClaw);
-            process.exitCode = 1;
-            return;
-          }
-          if (!isOpenClawAgentConfigured(config)) {
-            console.error('! AgentGuard Cloud credential was rejected. Run `agentguard connect --key <key>` again.');
-            process.exitCode = 1;
-            return;
-          }
-          try {
-            registration = await registerAgentCredential({
-              cloudUrl: config.cloudUrl,
-              reason: 'subscribe',
-              notifyOpenClaw: resolveCronAgentHost(config) === 'openclaw',
-              resetExistingJwt: true,
-            });
-            config = registration.config;
-            client = registration.client;
-            await client.subscribeFeed();
-          } catch (retryErr) {
-            if (cronNotifyRun) {
-              console.log('NO_REPLY');
-              process.exitCode = 0;
+      if (!cronInternalRun) {
+        try {
+          await client.subscribeFeed();
+        } catch (err) {
+          if (err instanceof CloudRequestError && err.status === 401) {
+            if (!isOpenClawAgentConfigured(config)) {
+              console.error('! AgentGuard Cloud credential was rejected. Run `agentguard connect --key <key>` again.');
+              process.exitCode = 1;
               return;
             }
-            printAgentActivationRequired(registration, retryErr);
+            try {
+              registration = await registerAgentCredential({
+                cloudUrl: config.cloudUrl,
+                reason: 'subscribe',
+                notifyOpenClaw: resolveCronAgentHost(config) === 'openclaw',
+                resetExistingJwt: true,
+              });
+              config = registration.config;
+              client = registration.client;
+              await client.subscribeFeed();
+            } catch (retryErr) {
+              printAgentActivationRequired(registration, retryErr);
+              process.exitCode = 1;
+              return;
+            }
+          } else {
+            console.error(`! Could not subscribe to AgentGuard Cloud feed: ${(err as Error).message}`);
             process.exitCode = 1;
             return;
           }
-        } else {
-          if (cronNotifyRun) {
-            console.log('NO_REPLY');
-            process.exitCode = 0;
-            return;
-          }
-          console.error(`! Could not subscribe to AgentGuard Cloud feed: ${(err as Error).message}`);
-          process.exitCode = 1;
-          return;
         }
       }
 

--- a/src/runtime/protect.ts
+++ b/src/runtime/protect.ts
@@ -48,6 +48,7 @@ export async function protectAction(options: ProtectOptions): Promise<ProtectRes
     decision = normalizeRuntimeDecision(await evaluateLocalAction(policy, action));
     policySource = source;
   }
+  if (isEmptySafeDecision(decision)) return null;
 
   const event: RuntimeAuditEvent = {
     ...action,
@@ -91,6 +92,10 @@ function normalizeRuntimeDecision(decision: RuntimeDecision): RuntimeDecision {
     return { ...decision, decision: 'require_approval' };
   }
   return decision;
+}
+
+function isEmptySafeDecision(decision: RuntimeDecision): boolean {
+  return decision.riskScore === 0 && decision.riskLevel === 'safe' && decision.reasons.length === 0;
 }
 
 export function formatProtectResult(result: ProtectResult, json = false): string {

--- a/src/runtime/self-command.ts
+++ b/src/runtime/self-command.ts
@@ -1,4 +1,13 @@
-const AGENTGUARD_BINARIES = new Set(['agentguard', 'agentguard-mcp']);
+const SUPPORTED_AGENT_BINARIES = new Set([
+  'agentguard',
+  'agentguard-mcp',
+  'claude',
+  'claude-code',
+  'codex',
+  'openclaw',
+  'qclaw',
+  'hermes',
+]);
 const SHELL_CONTROL_RE = /[;&|<>`]|\$\(/;
 
 export function isAgentGuardCliCommand(command: string): boolean {
@@ -19,7 +28,7 @@ export function isAgentGuardCliCommand(command: string): boolean {
     index += 1;
   }
 
-  return AGENTGUARD_BINARIES.has(basename(tokens[index] || ''));
+  return SUPPORTED_AGENT_BINARIES.has(basename(tokens[index] || ''));
 }
 
 function skipAssignments(tokens: string[], start: number): number {

--- a/src/tests/cli-subscribe.test.ts
+++ b/src/tests/cli-subscribe.test.ts
@@ -178,6 +178,76 @@ const advisory: Advisory = {
 };
 
 describe('CLI subscribe command modes', () => {
+  it('subscribes before pulling advisories during interactive subscribe runs', async () => {
+    const requests: string[] = [];
+    const server = http.createServer((req, res) => {
+      requests.push(`${req.method} ${req.url}`);
+      res.setHeader('content-type', 'application/json');
+      if (req.method === 'POST' && req.url === '/api/v1/feed/subscribe') {
+        res.end(JSON.stringify({ success: true, data: { id: 'sub_test', status: 'active' } }));
+        return;
+      }
+      if (req.method === 'GET' && req.url?.startsWith('/api/v1/feed/advisories')) {
+        res.end(JSON.stringify({ success: true, data: { advisories: [] } }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ success: false }));
+    });
+    await new Promise<void>((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise));
+    try {
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      const cloudUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+      const home = mkdtempSync(join(tmpdir(), 'ag-cli-subscribe-order-'));
+
+      const result = await runCli(['subscribe'], home, cloudUrl);
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stderr, '');
+      assert.deepEqual(requests, [
+        'POST /api/v1/feed/subscribe',
+        'GET /api/v1/feed/advisories',
+      ]);
+    } finally {
+      await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+    }
+  });
+
+  it('cron internal subscribe runs pull advisories without subscribing first', async () => {
+    for (const args of [
+      ['subscribe', '--json', '--cron-run'],
+      ['subscribe', '--cron-notify-run'],
+    ]) {
+      const requests: string[] = [];
+      const server = http.createServer((req, res) => {
+        requests.push(`${req.method} ${req.url}`);
+        res.setHeader('content-type', 'application/json');
+        if (req.method === 'GET' && req.url?.startsWith('/api/v1/feed/advisories')) {
+          res.end(JSON.stringify({ success: true, data: { advisories: [] } }));
+          return;
+        }
+        res.statusCode = 404;
+        res.end(JSON.stringify({ success: false }));
+      });
+      await new Promise<void>((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise));
+      try {
+        const address = server.address();
+        assert.ok(address && typeof address === 'object');
+        const cloudUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+        const home = mkdtempSync(join(tmpdir(), 'ag-cli-subscribe-cron-order-'));
+
+        const result = await runCli(args, home, cloudUrl);
+
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.stderr, '');
+        assert.deepEqual(requests, ['GET /api/v1/feed/advisories']);
+      } finally {
+        await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+      }
+    }
+  });
+
   it('without --quiet notifies about new advisories without reporting self-check matches', async () => {
     await withFeedServer([advisory], async (cloudUrl, reports) => {
       const home = mkdtempSync(join(tmpdir(), 'ag-cli-subscribe-'));
@@ -468,7 +538,7 @@ describe('CLI subscribe command modes', () => {
         }));
         return;
       }
-      if (req.method === 'POST' && req.url === '/api/v1/feed/subscribe') {
+      if (req.method === 'GET' && req.url?.startsWith('/api/v1/feed/advisories')) {
         authHeaders.push(req.headers.authorization);
         res.statusCode = 401;
         res.setHeader('content-type', 'application/json');

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -24,6 +24,16 @@ describe('Integration: Claude Code evaluateHook', () => {
     assert.equal(result.decision, 'allow');
   });
 
+  it('should ALLOW supported agent CLI commands', async () => {
+    ctx = createTestContext('balanced');
+    const result = await evaluateHook(ctx.claudeAdapter, {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'openclaw gateway restart' },
+    }, ctx.options);
+    assert.equal(result.decision, 'allow');
+  });
+
   it('should DENY rm -rf /', async () => {
     ctx = createTestContext('balanced');
     const result = await evaluateHook(ctx.claudeAdapter, {

--- a/src/tests/runtime-cloud.test.ts
+++ b/src/tests/runtime-cloud.test.ts
@@ -307,6 +307,57 @@ describe('Runtime Cloud bridge', () => {
     }
   });
 
+  it('skips supported agent CLI commands before local audit or Cloud reporting', async () => {
+    const originalFetch = globalThis.fetch;
+    const dir = mkdtempSync(join(tmpdir(), 'agentguard-agent-cli-'));
+    const requests: string[] = [];
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      requests.push(String(input));
+      throw new Error('unexpected cloud request');
+    }) as typeof fetch;
+
+    try {
+      const config: AgentGuardConfig = {
+        version: 1,
+        level: 'balanced',
+        cloudUrl: 'https://agentguard.example',
+        apiKey: 'ag_live_test_key_123456',
+        policyCachePath: join(dir, 'policy.json'),
+        auditPath: join(dir, 'audit.jsonl'),
+        eventSpoolPath: join(dir, 'spool.jsonl'),
+      };
+
+      for (const command of [
+        'openclaw gateway restart',
+        'qclaw gateway restart',
+        'hermes config reload',
+        'codex --version',
+        'claude mcp list',
+        'claude-code --version',
+        'env AGENTGUARD_AGENT_HOST=openclaw openclaw gateway restart',
+        'command codex --version',
+      ]) {
+        const result = await protectAction({
+          config,
+          stdinText: JSON.stringify({
+            tool_name: 'Bash',
+            tool_input: { command },
+            session_id: 'sess_test',
+          }),
+        });
+
+        assert.equal(result, null);
+      }
+
+      assert.deepEqual(requests, []);
+      assert.equal(existsSync(config.auditPath), false);
+      assert.equal(existsSync(config.eventSpoolPath), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('does not skip compound shell commands just because they mention agentguard', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'agentguard-compound-cli-'));
     const config: AgentGuardConfig = {
@@ -323,6 +374,31 @@ describe('Runtime Cloud bridge', () => {
       stdinText: JSON.stringify({
         tool_name: 'Bash',
         tool_input: { command: 'agentguard status; rm -rf /' },
+        session_id: 'sess_test',
+      }),
+    });
+
+    assert.ok(result);
+    assert.equal(result.decision.decision, 'block');
+    assert.equal(existsSync(config.auditPath), true);
+  });
+
+  it('does not skip compound shell commands just because they mention agent CLIs', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agentguard-agent-compound-cli-'));
+    const config: AgentGuardConfig = {
+      version: 1,
+      level: 'balanced',
+      cloudUrl: 'https://agentguard.example',
+      policyCachePath: join(dir, 'policy.json'),
+      auditPath: join(dir, 'audit.jsonl'),
+      eventSpoolPath: join(dir, 'spool.jsonl'),
+    };
+
+    const result = await protectAction({
+      config,
+      stdinText: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'openclaw gateway status; rm -rf /' },
         session_id: 'sess_test',
       }),
     });

--- a/src/tests/runtime-cloud.test.ts
+++ b/src/tests/runtime-cloud.test.ts
@@ -436,6 +436,107 @@ describe('Runtime Cloud bridge', () => {
     assert.equal(result?.decision.decision, 'block');
   });
 
+  it('does not audit or sync empty safe local runtime decisions', async () => {
+    const originalFetch = globalThis.fetch;
+    const dir = mkdtempSync(join(tmpdir(), 'agentguard-safe-noop-'));
+    const policy = getDefaultEffectiveRuntimePolicy();
+    const requests: string[] = [];
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = String(input);
+      requests.push(url);
+      if (url.endsWith('/api/v1/policies/effective')) {
+        return jsonResponse({ success: true, data: policy });
+      }
+      if (url.endsWith('/api/v1/events/ingest')) {
+        throw new Error('safe decisions should not be synced');
+      }
+      return jsonResponse({ success: false, error: { message: 'not found' } }, 404);
+    }) as typeof fetch;
+
+    try {
+      const config: AgentGuardConfig = {
+        version: 1,
+        level: 'balanced',
+        cloudUrl: 'https://agentguard.example',
+        apiKey: 'ag_live_test_key_123456',
+        policyCachePath: join(dir, 'policy.json'),
+        auditPath: join(dir, 'audit.jsonl'),
+        eventSpoolPath: join(dir, 'spool.jsonl'),
+      };
+
+      const result = await protectAction({
+        config,
+        stdinText: JSON.stringify({
+          tool_name: 'Bash',
+          tool_input: { command: 'echo hello' },
+          session_id: 'sess_safe',
+        }),
+      });
+
+      assert.equal(result, null);
+      assert.deepEqual(requests, ['https://agentguard.example/api/v1/policies/effective']);
+      assert.equal(existsSync(config.auditPath), false);
+      assert.equal(existsSync(config.eventSpoolPath), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('does not intercept empty safe Cloud require_approval decisions', async () => {
+    const originalFetch = globalThis.fetch;
+    const dir = mkdtempSync(join(tmpdir(), 'agentguard-cloud-safe-noop-'));
+    const requests: string[] = [];
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = String(input);
+      requests.push(url);
+      if (url.endsWith('/api/v1/actions/evaluate')) {
+        return jsonResponse({
+          success: true,
+          data: {
+            actionId: 'act_cloud_empty_safe',
+            decision: 'require_approval',
+            riskScore: 0,
+            riskLevel: 'safe',
+            reasons: [],
+            policyVersion: 'cloud-test',
+          },
+        });
+      }
+      return jsonResponse({ success: false, error: { message: 'not found' } }, 404);
+    }) as typeof fetch;
+
+    try {
+      const config: AgentGuardConfig = {
+        version: 1,
+        level: 'balanced',
+        cloudUrl: 'https://agentguard.example',
+        apiKey: 'ag_live_test_key_123456',
+        policyCachePath: join(dir, 'policy.json'),
+        auditPath: join(dir, 'audit.jsonl'),
+        eventSpoolPath: join(dir, 'spool.jsonl'),
+      };
+
+      const result = await protectAction({
+        config,
+        decisionMode: 'cloud',
+        stdinText: JSON.stringify({
+          tool_name: 'Bash',
+          tool_input: { command: 'echo hello' },
+          session_id: 'sess_cloud_safe',
+        }),
+      });
+
+      assert.equal(result, null);
+      assert.deepEqual(requests, ['https://agentguard.example/api/v1/actions/evaluate']);
+      assert.equal(existsSync(config.auditPath), false);
+      assert.equal(existsSync(config.eventSpoolPath), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('syncs redacted audit events and uses agent approval by default on require_approval', async () => {
     const originalFetch = globalThis.fetch;
     const dir = mkdtempSync(join(tmpdir(), 'agentguard-cloud-ok-'));


### PR DESCRIPTION
## Summary

- Change `agentguard subscribe` cron internals so `--cron-run` and `--cron-notify-run` only pull advisories instead of re-subscribing on every scheduled run.
- Preserve Cloud-side unsubscribe choices by keeping auto-subscribe behavior only for normal interactive `agentguard subscribe` runs.
- Allow supported agent CLI commands such as `openclaw`, `qclaw`, `hermes`, `codex`, and `claude` to pass through AgentGuard self-command handling.
- Skip local interception, audit writes, and Cloud event sync for empty safe runtime decisions: `riskScore: 0`, `riskLevel: safe`, and `reasons: []`.
- Add Unreleased changelog entries.

## Testing

- `npm run build`
- `node --test dist/tests/cli-subscribe.test.js`
- `node --test dist/tests/runtime-cloud.test.js`
- `node --test dist/tests/integration.test.js`
- `npm test`

## Type

- [x] Bug fix
- [ ] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [x] `npm run build` passes
- [x] `npm test` passes (32 tests)
- [ ] Manually tested the change

## Related Issues

Closes #
