### PR TITLE
Fix agent CLI self-command allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.1.23] - 2026-05-28
+## [1.1.24] - 2026-05-28
 
 ### Added
 - Added local one-time runtime approval grants: `agentguard approve --action-id <id> --once`, `agentguard approve --last --once`, and `agentguard approvals list` let agents retry a previously intercepted protected action after explicit user approval, with short-lived pending approvals and audited approved retries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@goplus/agentguard",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goplus/agentguard",
-      "version": "1.1.23",
+      "version": "1.1.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goplus/agentguard",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "GoPlus AgentGuard — Security guard for AI agents. Blocks dangerous commands, prevents data leaks, protects secrets. 20 detection rules, runtime action evaluation, trust registry.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/adapters/openclaw-plugin.ts
+++ b/src/adapters/openclaw-plugin.ts
@@ -459,6 +459,9 @@ export function registerOpenClawPlugin(
           if (hookDecision) {
             return hookDecision;
           }
+          if (isApprovedLocalRuntimeRetry(runtimeResult)) {
+            return undefined;
+          }
         } catch (err) {
           if (
             options.runtimeFailureMode !== 'fallback' &&
@@ -693,6 +696,10 @@ function shouldSurfaceRuntimeApproval(result: ProtectResult): boolean {
     result.decision.riskScore > 0 ||
     result.decision.reasons.length > 0
   );
+}
+
+function isApprovedLocalRuntimeRetry(result: ProtectResult | null): boolean {
+  return result?.decision.decision === 'allow' && result.event.metadata?.approvedByLocalGrant === true;
 }
 
 function normalizeRuntimePolicyDecision(decision: ProtectResult['decision']['decision'] | string): ProtectResult['decision']['decision'] {

--- a/src/adapters/openclaw-plugin.ts
+++ b/src/adapters/openclaw-plugin.ts
@@ -586,6 +586,10 @@ function mapOpenClawToolToRuntimeAction(
     return 'network';
   }
 
+  const record = isRecord(event) ? event : undefined;
+  if (typeof record?.command === 'string' || typeof record?.cmd === 'string') {
+    return 'shell';
+  }
   const params = readOpenClawParams(event);
   if (typeof params?.command === 'string' || typeof params?.cmd === 'string') {
     return 'shell';
@@ -617,8 +621,14 @@ function mapOpenClawToolToRuntimeAction(
 
 function readOpenClawParams(event: unknown): Record<string, unknown> | undefined {
   const record = isRecord(event) ? event : undefined;
-  const params = record?.params ?? record?.toolInput ?? record?.tool_input;
-  return isRecord(params) ? params : undefined;
+  const params = firstRecord(
+    record?.params,
+    record?.toolInput,
+    record?.tool_input,
+    record?.args,
+    record?.input
+  );
+  return params;
 }
 
 function isSecuritySensitiveRuntimeAction(actionType: RuntimeActionType): boolean {
@@ -708,6 +718,13 @@ function normalizeRuntimePolicyDecision(decision: ProtectResult['decision']['dec
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function firstRecord(...values: unknown[]): Record<string, unknown> | undefined {
+  for (const value of values) {
+    if (isRecord(value)) return value;
+  }
+  return undefined;
 }
 
 /**

--- a/src/adapters/openclaw.ts
+++ b/src/adapters/openclaw.ts
@@ -29,9 +29,15 @@ export class OpenClawAdapter implements HookAdapter {
 
   parseInput(raw: unknown): HookInput {
     const event = raw as Record<string, unknown>;
+    const toolInput =
+      (event.params as Record<string, unknown>) ||
+      (event.toolInput as Record<string, unknown>) ||
+      (event.tool_input as Record<string, unknown>) ||
+      (event.args as Record<string, unknown>) ||
+      {};
     return {
-      toolName: (event.toolName as string) || '',
-      toolInput: (event.params as Record<string, unknown>) || {},
+      toolName: (event.toolName as string) || (event.tool_name as string) || '',
+      toolInput,
       eventType: 'pre', // before_tool_call = pre
       raw: event,
     };

--- a/src/runtime/evaluator.ts
+++ b/src/runtime/evaluator.ts
@@ -33,6 +33,17 @@ export async function evaluateLocalAction(
   policy: EffectiveRuntimePolicy,
   action: RuntimeAction
 ): Promise<RuntimeDecision> {
+  if (isAllowedByCommandPolicy(policy, action)) {
+    return {
+      actionId: `act_local_${Date.now()}_${process.pid}`,
+      decision: 'allow',
+      riskScore: 0,
+      riskLevel: 'safe',
+      reasons: [],
+      policyVersion: policy.policyVersion || 'runtime-local-v0.1',
+    };
+  }
+
   const customReasons = customPolicyReasons(policy, action);
   const ossDecision = await evaluateWithOssActionScanner(policy, action);
   const ossReasons = (ossDecision?.risk_tags || []).map((tag, index) =>
@@ -51,6 +62,11 @@ export async function evaluateLocalAction(
     reasons,
     policyVersion: policy.policyVersion || 'runtime-local-v0.1',
   };
+}
+
+function isAllowedByCommandPolicy(policy: EffectiveRuntimePolicy, action: RuntimeAction): boolean {
+  if (action.actionType !== 'shell') return false;
+  return policy.allowedCommandPatterns.some((pattern) => matchesAllowedCommand(action.input, pattern));
 }
 
 function customPolicyReasons(policy: EffectiveRuntimePolicy, action: RuntimeAction): PolicyReason[] {
@@ -246,6 +262,46 @@ function matchesPattern(input: string, pattern: string): boolean {
   if (input.includes(pattern)) return true;
   const compact = pattern.replace(/\s*\.\.\.\s*/g, ' ');
   return compact !== pattern && input.includes(compact);
+}
+
+function matchesAllowedCommand(input: string, pattern: string): boolean {
+  const trimmedInput = input.trim();
+  const trimmedPattern = pattern.trim();
+  if (!trimmedInput || !trimmedPattern) return false;
+
+  const inputHasControl = hasShellControl(trimmedInput);
+  const patternHasControl = hasShellControl(trimmedPattern);
+  if (inputHasControl && !patternHasControl) return false;
+
+  const normalizedInput = normalizeCommand(trimmedInput);
+  const normalizedPattern = normalizeCommand(trimmedPattern);
+  if (normalizedPattern === '*') return true;
+  if (/[?*]/.test(normalizedPattern) || normalizedPattern.includes('...')) {
+    const regex = new RegExp(`^${globCommandToRegexSource(normalizedPattern)}$`);
+    return regex.test(normalizedInput);
+  }
+
+  return normalizedInput === normalizedPattern ||
+    (!inputHasControl && normalizedInput.startsWith(`${normalizedPattern} `));
+}
+
+function normalizeCommand(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function hasShellControl(command: string): boolean {
+  return /[;&|<>`\n\r\t]|\$\(/.test(command);
+}
+
+function globCommandToRegexSource(pattern: string): string {
+  const normalized = pattern.replace(/\s*\.\.\.\s*/g, ' * ');
+  let source = '';
+  for (const char of normalized) {
+    if (char === '*') source += '.*';
+    else if (char === '?') source += '.';
+    else source += escapeRegex(char);
+  }
+  return source;
 }
 
 function matchesPath(input: string, pattern: string): boolean {

--- a/src/runtime/protect.ts
+++ b/src/runtime/protect.ts
@@ -264,6 +264,7 @@ function mapToolToRuntimeAction(toolName: string, raw: Record<string, unknown> |
   if (['Write', 'Edit', 'MultiEdit'].includes(toolName) || lower.includes('write')) return 'file_write';
   if (lower.includes('web') || lower.includes('browser')) return 'network';
   if (raw?.actionType && typeof raw.actionType === 'string') return raw.actionType as RuntimeActionType;
+  if (raw?.action_type && typeof raw.action_type === 'string') return raw.action_type as RuntimeActionType;
   return 'other';
 }
 
@@ -271,16 +272,45 @@ function pickInput(raw: Record<string, unknown> | null, actionType: RuntimeActio
   if (!raw) return '';
   if (typeof raw.input === 'string') return raw.input;
   if (typeof raw.content === 'string') return raw.content;
-  const toolInput = (raw.tool_input || raw.toolInput || raw.params) as Record<string, unknown> | undefined;
-  if (toolInput && typeof toolInput === 'object') {
-    if (actionType === 'shell' && typeof toolInput.command === 'string') return toolInput.command;
-    const filePath = toolInput.file_path || toolInput.path;
+  if (actionType === 'shell') {
+    const command = firstString(raw.command, raw.cmd);
+    if (command) return command;
+  }
+  const toolInput = firstRecord(
+    raw.tool_input,
+    raw.toolInput,
+    raw.params,
+    raw.args,
+    raw.input
+  );
+  if (toolInput) {
+    if (actionType === 'shell') {
+      const command = firstString(toolInput.command, toolInput.cmd);
+      if (command) return command;
+    }
+    const filePath = toolInput.file_path || toolInput.filePath || toolInput.path || toolInput.target;
     if ((actionType === 'file_read' || actionType === 'file_write') && typeof filePath === 'string') return filePath;
-    const url = toolInput.url || toolInput.query;
+    const url = toolInput.url || toolInput.uri || toolInput.href || toolInput.query;
     if (typeof url === 'string') return url;
     return JSON.stringify(toolInput);
   }
   return JSON.stringify(raw);
+}
+
+function firstRecord(...values: unknown[]): Record<string, unknown> | undefined {
+  for (const value of values) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+  }
+  return undefined;
+}
+
+function firstString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return '';
 }
 
 function pickSessionId(raw: Record<string, unknown> | null): string {

--- a/src/runtime/self-command.ts
+++ b/src/runtime/self-command.ts
@@ -1,4 +1,4 @@
-const SUPPORTED_AGENT_BINARIES = new Set([
+const SUPPORTED_AGENT_COMMANDS = [
   'agentguard',
   'agentguard-mcp',
   'claude',
@@ -7,8 +7,13 @@ const SUPPORTED_AGENT_BINARIES = new Set([
   'openclaw',
   'qclaw',
   'hermes',
-]);
-const SHELL_CONTROL_RE = /[;&|<>`]|\$\(/;
+  'cursor',
+  'cursor-agent',
+  'gemini',
+  'copilot',
+  'gh copilot',
+];
+const SHELL_CONTROL_RE = /[;&|<>`\n\r\t]|\$\(/;
 
 export function isAgentGuardCliCommand(command: string): boolean {
   const trimmed = command.trim();
@@ -28,7 +33,13 @@ export function isAgentGuardCliCommand(command: string): boolean {
     index += 1;
   }
 
-  return SUPPORTED_AGENT_BINARIES.has(basename(tokens[index] || ''));
+  return SUPPORTED_AGENT_COMMANDS.some((command) => matchesCommand(tokens, index, command));
+}
+
+function matchesCommand(tokens: string[], start: number, command: string): boolean {
+  const expected = command.split(/\s+/);
+  if (start + expected.length > tokens.length) return false;
+  return expected.every((part, offset) => basename(tokens[start + offset] || '') === part);
 }
 
 function skipAssignments(tokens: string[], start: number): number {

--- a/src/tests/adapter.test.ts
+++ b/src/tests/adapter.test.ts
@@ -208,6 +208,15 @@ describe('OpenClawAdapter', () => {
       assert.deepEqual(input.toolInput, {});
     });
 
+    it('should fall back to args/cmd payloads', () => {
+      const input = adapter.parseInput({
+        toolName: 'terminal',
+        args: { cmd: 'agentguard disconnect' },
+      });
+      assert.equal(input.toolName, 'terminal');
+      assert.deepEqual(input.toolInput, { cmd: 'agentguard disconnect' });
+    });
+
     it('should handle empty event', () => {
       const input = adapter.parseInput({});
       assert.equal(input.toolName, '');

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -264,6 +264,21 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
     assert.equal(result, undefined, 'Ordinary OpenClaw exec command should be allowed');
   });
 
+  it('should allow AgentGuard CLI commands from OpenClaw args/cmd payloads', async () => {
+    ctx = createTestContext();
+    const { api, handlers } = createMockApi();
+    registerOpenClawPlugin(api as never, {
+      skipAutoScan: true,
+      registry: ctx.agentguard.registry as never,
+    });
+
+    const result = await handlers['before_tool_call']({
+      toolName: 'terminal',
+      args: { cmd: 'agentguard disconnect' },
+    });
+    assert.equal(result, undefined, 'AgentGuard self-command should be allowed');
+  });
+
   it('should run runtime protection for OpenClaw tool calls', async () => {
     ctx = createTestContext();
     const { api, handlers } = createMockApi();

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -495,6 +495,51 @@ describe('Integration: OpenClaw registerOpenClawPlugin', () => {
     assert.ok(result?.blockReason?.includes('requires approval'));
   });
 
+  it('should allow OpenClaw retries that consumed a local one-time approval', async () => {
+    ctx = createTestContext();
+    const { api, handlers } = createMockApi();
+    registerOpenClawPlugin(api as never, {
+      skipAutoScan: true,
+      agentguardFactory: () => ctx.agentguard as never,
+      protectAction: async () => ({
+        policySource: 'default',
+        approvalChannel: undefined,
+        event: {
+          actionId: 'act_retry',
+          sessionId: 'openclaw-session',
+          agentHost: 'openclaw',
+          actionType: 'shell',
+          toolName: 'exec',
+          input: 'cat ~/.ssh/id_ed25519.pub',
+          decision: 'allow',
+          riskScore: 55,
+          riskLevel: 'high',
+          reasons: [],
+          policyVersion: 'runtime-test',
+          metadata: {
+            approvedByLocalGrant: true,
+            approvalActionId: 'act_original',
+          },
+        },
+        decision: {
+          actionId: 'act_retry',
+          decision: 'allow',
+          riskScore: 55,
+          riskLevel: 'high',
+          policyVersion: 'runtime-test',
+          reasons: [],
+        },
+      }),
+    });
+
+    const result = await handlers['before_tool_call']({
+      toolName: 'exec',
+      params: { command: 'cat ~/.ssh/id_ed25519.pub' },
+    }) as { block?: boolean; blockReason?: string } | undefined;
+
+    assert.equal(result, undefined);
+  });
+
   it('should return { block: true } for rm -rf /', async () => {
     ctx = createTestContext();
     const { api, handlers } = createMockApi();

--- a/src/tests/runtime-cloud.test.ts
+++ b/src/tests/runtime-cloud.test.ts
@@ -308,6 +308,81 @@ describe('Runtime Cloud bridge', () => {
     }
   });
 
+  it('skips AgentGuard CLI commands from alternate tool argument shapes', async () => {
+    const originalFetch = globalThis.fetch;
+    const dir = mkdtempSync(join(tmpdir(), 'agentguard-self-cli-args-'));
+    const requests: string[] = [];
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      requests.push(String(input));
+      throw new Error('unexpected cloud request');
+    }) as typeof fetch;
+
+    try {
+      const config: AgentGuardConfig = {
+        version: 1,
+        level: 'balanced',
+        cloudUrl: 'https://agentguard.example',
+        apiKey: 'ag_live_test_key_123456',
+        policyCachePath: join(dir, 'policy.json'),
+        auditPath: join(dir, 'audit.jsonl'),
+        eventSpoolPath: join(dir, 'spool.jsonl'),
+      };
+
+      const result = await protectAction({
+        config,
+        actionType: 'shell',
+        stdinText: JSON.stringify({
+          toolName: 'terminal',
+          args: { cmd: 'agentguard disconnect' },
+          sessionId: 'sess_test',
+        }),
+      });
+
+      assert.equal(result, null);
+      assert.deepEqual(requests, []);
+      assert.equal(existsSync(config.auditPath), false);
+      assert.equal(existsSync(config.eventSpoolPath), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('honors allowed command patterns without allowing compound shell commands', async () => {
+    const policy = getDefaultEffectiveRuntimePolicy();
+    policy.blockedCommandPatterns = ['agentguard'];
+    policy.allowedCommandPatterns = ['agentguard'];
+
+    const allowed = await evaluateLocalAction(policy, {
+      sessionId: 'sess_test',
+      agentHost: 'openclaw',
+      actionType: 'shell',
+      toolName: 'exec',
+      input: 'agentguard disconnect',
+    });
+    assert.equal(allowed.decision, 'allow');
+    assert.equal(allowed.riskScore, 0);
+    assert.deepEqual(allowed.reasons, []);
+
+    const compound = await evaluateLocalAction(policy, {
+      sessionId: 'sess_test',
+      agentHost: 'openclaw',
+      actionType: 'shell',
+      toolName: 'exec',
+      input: 'agentguard status; rm -rf /',
+    });
+    assert.equal(compound.decision, 'block');
+
+    const multiline = await evaluateLocalAction(policy, {
+      sessionId: 'sess_test',
+      agentHost: 'openclaw',
+      actionType: 'shell',
+      toolName: 'exec',
+      input: 'agentguard status\nrm -rf /',
+    });
+    assert.equal(multiline.decision, 'block');
+  });
+
   it('skips supported agent CLI commands before local audit or Cloud reporting', async () => {
     const originalFetch = globalThis.fetch;
     const dir = mkdtempSync(join(tmpdir(), 'agentguard-agent-cli-'));
@@ -336,6 +411,11 @@ describe('Runtime Cloud bridge', () => {
         'codex --version',
         'claude mcp list',
         'claude-code --version',
+        'cursor-agent --version',
+        'cursor --version',
+        'gemini --version',
+        'copilot --version',
+        'gh copilot explain "git status"',
         'env AGENTGUARD_AGENT_HOST=openclaw openclaw gateway restart',
         'command codex --version',
       ]) {
@@ -375,6 +455,31 @@ describe('Runtime Cloud bridge', () => {
       stdinText: JSON.stringify({
         tool_name: 'Bash',
         tool_input: { command: 'agentguard status; rm -rf /' },
+        session_id: 'sess_test',
+      }),
+    });
+
+    assert.ok(result);
+    assert.equal(result.decision.decision, 'block');
+    assert.equal(existsSync(config.auditPath), true);
+  });
+
+  it('does not skip multiline shell commands just because they start with agent CLIs', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agentguard-agent-multiline-cli-'));
+    const config: AgentGuardConfig = {
+      version: 1,
+      level: 'balanced',
+      cloudUrl: 'https://agentguard.example',
+      policyCachePath: join(dir, 'policy.json'),
+      auditPath: join(dir, 'audit.jsonl'),
+      eventSpoolPath: join(dir, 'spool.jsonl'),
+    };
+
+    const result = await protectAction({
+      config,
+      stdinText: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'openclaw gateway status\nrm -rf /' },
         session_id: 'sess_test',
       }),
     });


### PR DESCRIPTION
## Summary

- Allow AgentGuard and supported agent CLI management commands to bypass runtime interception
- Support additional OpenClaw/Hermes-style payload shapes such as `args.cmd`, `cmd`, `toolInput`, and `input.command`
- Make runtime `allowedCommandPatterns` effective while preserving compound/multiline command blocking
- Add regression coverage for agent CLI allowlisting, OpenClaw argument parsing, and compound command safety

## Testing

- `npm run build`
- `npm test`
## Type

- [ ] Bug fix
- [ ] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [ ] `npm run build` passes
- [ ] `npm test` passes (32 tests)
- [ ] Manually tested the change

## Related Issues

Closes #
