### PR TITLE
fix: complete recursive DSH checkup scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Improved DSH subscription cleanup and artifact discovery, and made system cron status failures explicit.
+- Fixed `checkup` to recursively scan plugins referenced by DSH bundles, wait for all DSH scans before report generation, and include per-plugin results in JSON and HTML reports.
 
 ## [1.1.29] - 2026-08-26
 

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -95,9 +95,11 @@ Scheduled self-check discovery includes `$DSH_HOME/skills` (default
 `~/.dsh/skills`), `<current-project>/.dsh/skills`, every immediate
 `$DSH_HOME/profiles/*/package.json`, each profile's declared direct and optional
 dependencies under `node_modules`, and existing `cordis.patch.yml` or
-`cordis.patch.yaml` files in the DSH home and profile directories. Dependency
-discovery is deliberately non-recursive: undeclared transitive packages and
-dependency names that could escape `node_modules` are excluded. Advisory-level
+`cordis.patch.yaml` files in the DSH home and profile directories. When a direct
+dependency is a DSH bundle, discovery follows package dependencies named by its
+Cordis plugin rows recursively, including pnpm virtual-store layouts. Unrelated
+transitive packages and dependency names that could escape `node_modules` stay
+excluded. Advisory-level
 `inspectPaths` and explicitly supplied self-check roots remain authoritative.
 
 For local checkout testing, install the CLI from a packed tarball but keep the

--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -1058,7 +1058,7 @@ Run these checks in parallel where possible. These are **universal agent securit
 
    For **every** discovered skill, **run `/agentguard scan <skill_path>`** using the scan subcommand logic (24 detection rules). Do NOT skip any skill regardless of how many are found. Record for each skill: name, risk_level, and exact findings list (rule, severity, file, line).
 
-   Also discover installed DSH plugins under the resolved DSH home: use the non-empty `DSH_HOME` value when set, otherwise use the current user's real home directory plus `.dsh` (do not pass a literal unexpanded `~` to path APIs). Inspect `${dshHome}/profiles/*`; read each immediate profile's `package.json`, collect only names declared in `dependencies` and `optionalDependencies`, and resolve their existing directories beneath that same profile's `node_modules/`. Do not recursively walk `node_modules` or scan transitive-only dependencies. Exclude only the exact `@goplus/agentguard` dependency coordinate declared by the profile; never trust an installed plugin's self-reported package name for this exclusion. For **every** remaining direct plugin, run `agentguard dsh-scan <plugin_path> --format json` and record its name, `riskLevel`, and exact findings list (`ruleId`, severity, file, line), normalized to the raw-facts schema below. A failed DSH plugin scan must not prevent the remaining checks from completing; record it in `dsh_plugins` with `risk_level: "high"` and one finding `{ "rule": "DSH_SCAN_FAILED", "severity": "HIGH", "file": "<plugin_path>", "line": 0 }`.
+   Also discover installed DSH plugins under the resolved DSH home: use the non-empty `DSH_HOME` value when set, otherwise use the current user's real home directory plus `.dsh` (do not pass a literal unexpanded `~` to path APIs). Inspect `${dshHome}/profiles/*`; read each immediate profile's `package.json`, collect only names declared in `dependencies` and `optionalDependencies`, and resolve their existing directories beneath that same profile's `node_modules/`. For a dependency that declares `dsh.bundle.patch`, parse its Cordis patch and recursively resolve only package dependencies actually named by plugin rows in that patch; repeat for referenced child bundles, with path deduplication, cycle detection, and a bounded depth. Do not enumerate or scan unrelated transitive dependencies. Exclude only the exact `@goplus/agentguard` dependency coordinate declared by the profile or referenced by a bundle; never trust an installed plugin's self-reported package name for this exclusion. For **every** discovered direct or bundle-referenced plugin, run `agentguard dsh-scan <plugin_path> --format json` and record its name, path, `riskLevel`, and exact findings list (`ruleId`, severity, file, line), normalized to the raw-facts schema below. A failed DSH plugin scan must not prevent the remaining checks from completing; record it in `dsh_plugins` with `risk_level: "high"` and one finding `{ "rule": "DSH_SCAN_FAILED", "severity": "HIGH", "file": "<plugin_path>", "line": 0 }`.
 2. **[REQUIRED] Credential file permissions** (→ feeds Dimension 2: Credential Safety): Platform-aware check — behavior differs by OS:
    - **macOS/Linux**: Run `stat -f '%Lp' <path> 2>/dev/null || stat -c '%a' <path> 2>/dev/null` on `~/.ssh/`, `~/.gnupg/`. **If the command returns empty output, the directory does not exist — record `exists: false`.**
    - **Windows**: `stat` is not available. Use `icacls <path>` to check ACLs instead. If directory doesn't exist, record `exists: false`. If it exists, record whether the ACL grants access to `Everyone`, `Users`, or `Authenticated Users`.
@@ -1078,6 +1078,8 @@ Run these checks in parallel where possible. These are **universal agent securit
 6. **[REQUIRED] Environment variable exposure** (→ feeds Dimension 3: Network & System): Run `env` and check for sensitive variable names (`PRIVATE_KEY`, `MNEMONIC`, `SECRET`, `PASSWORD`) — detect presence only, mask values. Record list of sensitive variable names found.
 7. **[REQUIRED] Runtime protection check** (→ feeds Dimension 4: Runtime Protection): Check if security hooks exist in `~/.claude/settings.json`, `~/.openclaw/openclaw.json`, or `~/.hermes/config.yaml`. Check for audit logs at `~/.agentguard/audit.jsonl`. Check if installed skills have been previously scanned (audit log contains `scan` events). Record booleans: `hooks_installed`, `audit_log_exists`, `skills_ever_scanned`.
 
+**Completion barrier:** Parallel collection is allowed, but Step 2 MUST NOT begin while any skill scan, DSH plugin scan, bundle-child discovery, or other required check is still running. Await every spawned/background task, collect every exit status and output, and only then assemble raw facts. Never start `checkup-score.js` or `checkup-report.js` from the same parallel batch as a scan.
+
 ### Step 2: Assemble Raw Facts JSON
 
 After completing all 7 checks, assemble the raw facts into a structured JSON and write it to a temporary file (e.g. `/tmp/agentguard-raw-facts.json`):
@@ -1096,6 +1098,7 @@ After completing all 7 checks, assemble the raw facts into a structured JSON and
   "dsh_plugins": [
     {
       "name": "<plugin-name>",
+      "path": "<plugin-path>",
       "risk_level": "<low|medium|high|critical>",
       "findings": [
         { "rule": "<RULE_ID>", "severity": "<CRITICAL|HIGH|MEDIUM|LOW>", "file": "<filename>", "line": <number> }
@@ -1194,6 +1197,16 @@ Assemble the final JSON by merging the scored output from Step 3 with the analys
   },
   "skills_scanned": <count of skills from Step 1>,
   "dsh_plugins_scanned": <count of successfully scanned DSH plugins from Step 1>,
+  "dsh_plugins": [
+    {
+      "name": "<plugin-name>",
+      "path": "<plugin-path>",
+      "risk_level": "<low|medium|high|critical>",
+      "findings": [
+        { "rule": "<RULE_ID>", "severity": "<CRITICAL|HIGH|MEDIUM|LOW>", "file": "<filename>", "line": <number> }
+      ]
+    }
+  ],
   "protection_level": "<level>",
   "analysis": "<the comprehensive AI-written security analysis report>",
   "recommendations": [

--- a/skills/agentguard/scripts/checkup-report.js
+++ b/skills/agentguard/scripts/checkup-report.js
@@ -640,7 +640,7 @@ function pixelLobster(grade, color) {
 // ---------------------------------------------------------------------------
 
 function generateReport(data) {
-  const { composite_score = 0, dimensions = {}, recommendations = [], skills_scanned = 0, dsh_plugins_scanned = 0, protection_level = 'unknown', timestamp } = data;
+  const { composite_score = 0, dimensions = {}, recommendations = [], skills_scanned = 0, dsh_plugins_scanned = 0, dsh_plugins = [], protection_level = 'unknown', timestamp } = data;
   const tier = getTier(composite_score);
   const ctaUrl = `https://www.agentguard.one?utm_source=checkup&utm_medium=cli&utm_campaign=health_report&score=${composite_score}`;
   const ts = timestamp || new Date().toISOString();
@@ -725,6 +725,35 @@ function generateReport(data) {
     findingsPages.push(h);
   }
 
+  // ── DSH plugin scan results ──
+  const dshPluginPages = [];
+  const normalizedDshPlugins = Array.isArray(dsh_plugins) ? dsh_plugins : [];
+  const DSH_PLUGINS_PER_PAGE = 4;
+  for (let i = 0; i < normalizedDshPlugins.length; i += DSH_PLUGINS_PER_PAGE) {
+    const chunk = normalizedDshPlugins.slice(i, i + DSH_PLUGINS_PER_PAGE);
+    let h = `<div class="mb-6"><p class="text-xs font-label uppercase tracking-[0.2em] text-[#849588] mb-1" data-i18n="dsh_scan_results">DSH Plugin Scan Results</p><h1 class="text-3xl font-headline font-bold text-[#f5fff5] tracking-tight flex items-center gap-3"><span class="material-symbols-outlined text-[#98cbff]">extension</span><span data-i18n="dsh_plugins">DSH Plugins</span> <span class="text-[#849588] font-normal text-lg">(${normalizedDshPlugins.length})</span></h1></div>`;
+    h += chunk.map(plugin => {
+      const risk = String(plugin?.risk_level || 'unknown').toUpperCase();
+      const color = sevColor(risk);
+      const pluginFindings = Array.isArray(plugin?.findings) ? plugin.findings : [];
+      const findingsHtml = pluginFindings.length > 0
+        ? `<div class="mt-3 space-y-1">${pluginFindings.map(finding => {
+          const location = `${finding?.file || '?'}:${finding?.line ?? '?'}`;
+          return `<div class="text-xs text-[#b9cbbd] font-mono"><span style="color:${sevColor(finding?.severity)}">${esc(finding?.rule || 'UNKNOWN')}</span> <span class="text-[#849588]">${esc(location)}</span></div>`;
+        }).join('')}</div>`
+        : '<div class="mt-3 text-xs text-[#849588]" data-i18n="no_plugin_findings">No findings.</div>';
+      return `<div class="bg-[#1c2026] border border-[#3a4a3f]/15 rounded-xl p-4 mb-3" style="border-left:3px solid ${color}">
+        <div class="flex items-center justify-between gap-3">
+          <span class="font-headline font-semibold text-[#dfe2eb]">${esc(plugin?.name || 'unknown')}</span>
+          <span class="px-2.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wide text-white" style="background:${color}">${esc(risk)}</span>
+        </div>
+        <div class="mt-1 text-[10px] text-[#849588] font-mono break-all">${esc(plugin?.path || '')}</div>
+        ${findingsHtml}
+      </div>`;
+    }).join('');
+    dshPluginPages.push(h);
+  }
+
   // ── Recommendations ──
   // Auto-generate extra recommendations based on dimension scores
   const autoRecs = [];
@@ -783,7 +812,7 @@ function generateReport(data) {
   const healthLabel = composite_score >= 70 ? 'OPTIMAL' : composite_score >= 50 ? 'STABILIZING' : 'CRITICAL_ALERT';
 
   // ── Total pages ──
-  const totalPages = 1 + findingsPages.length + 1;
+  const totalPages = 1 + findingsPages.length + dshPluginPages.length + 1;
 
   const html = `<!DOCTYPE html>
 <html class="dark" lang="en"><head>
@@ -922,6 +951,15 @@ body{background:#0a0e14;color:#dfe2eb;font-family:'Inter',sans-serif}
       </div>
     </div>`).join('')}
 
+    <!-- DSH plugin scan results -->
+    ${dshPluginPages.map(content => `
+    <div class="w-full h-full shrink-0 px-4 sm:px-6 py-4 sm:py-5 overflow-hidden">
+      <div class="h-full rounded-xl p-4 sm:p-6 flex flex-col overflow-y-auto border border-[#3a4a3f]/10 relative" style="background:linear-gradient(145deg,#1c2026 0%,#151b22 100%)">
+        <div class="absolute top-0 right-0 w-48 h-48 rounded-full blur-[100px] opacity-[0.03] pointer-events-none" style="background:#98cbff"></div>
+        ${content}
+      </div>
+    </div>`).join('')}
+
     <!-- LAST PAGE: Security Analysis & Remediation -->
     <div class="w-full h-full shrink-0 px-4 sm:px-6 py-4 sm:py-5 overflow-hidden">
       <div class="h-full rounded-xl p-4 sm:p-6 flex flex-col overflow-y-auto border border-[#3a4a3f]/10 relative" style="background:linear-gradient(145deg,#1c2026 0%,#151d20 100%)">
@@ -1043,8 +1081,8 @@ body{background:#0a0e14;color:#dfe2eb;font-family:'Inter',sans-serif}
 
   // ── i18n ──
   const i18n={
-    en:{title:'AgentGuard Report',share:'Share',diag_metrics:'Diagnostic Metrics',sec_dims:'SECURITY DIMENSIONS',back:'Back',next:'Next',nav_overview:'Overview',nav_analysis:'Analysis',nav_report:'Report',vuln_stream:'Active Vulnerability Stream',findings:'Findings',sec_analysis:'Security Analysis',diag_report:'Diagnostic Report',action_items:'Action Items',cta_title:'Enhanced Skill Scanning',cta_desc:'Deeper code analysis, threat intelligence feeds & real-time protection.',cta_btn:'Upgrade Skill Scanning',artifacts_scanned:'Scanned artifacts',findings_label:'Findings',tier_label:'Tier',copy_report:'Copy Report',system_health:'System Health',dim_code_safety:'Skill & Code Safety',dim_credential_safety:'Credential & Secrets',dim_network_exposure:'Network & System',dim_runtime_protection:'Runtime Protection',dim_web3_safety:'Web3 Safety',no_threats_clean:'No active threats detected. Clinically sterile.',all_clear:'All Clear',no_threats_all:'No active threats detected across all dimensions.',share_report_title:'Share Report',generating_preview:'Generating preview...',copy_image:'Copy image to clipboard',share_img_hint:'📋 Clicking a platform copies the image — just paste when posting',no_recs:'No recommendations.',tier_badge:'TIER ${tier.grade} — ${tier.label}',status_label:'STATUS: ${healthLabel}',prot_mode:'${protection_level} mode',download_btn:'Download'},
-    zh:{title:'AgentGuard 诊断报告',share:'分享',diag_metrics:'诊断指标',sec_dims:'安全维度',back:'上一页',next:'下一页',nav_overview:'总览',nav_analysis:'威胁分析',nav_report:'诊断报告',vuln_stream:'活跃漏洞流',findings:'发现',sec_analysis:'安全分析',diag_report:'诊断报告',action_items:'修复建议',cta_title:'更强的 Skill 扫描',cta_desc:'更深度的代码分析、威胁情报推送、实时安全防护',cta_btn:'升级到更强的skill扫描',artifacts_scanned:'已扫描项目',findings_label:'发现',tier_label:'等级',copy_report:'复制报告',system_health:'系统健康',dim_code_safety:'技能与代码安全',dim_credential_safety:'凭证与密钥安全',dim_network_exposure:'网络与系统暴露',dim_runtime_protection:'运行时防护',dim_web3_safety:'Web3 安全',no_threats_clean:'未检测到活跃威胁，环境安全无虞。',all_clear:'全部通过',no_threats_all:'所有维度均未检测到活跃威胁。',share_report_title:'分享报告',generating_preview:'正在生成预览...',copy_image:'复制图片到剪贴板',share_img_hint:'📋 点击平台按钮会自动复制图片，去粘贴发出去就行',no_recs:'暂无修复建议。',tier_badge:'等级 ${tier.grade} — ${{S:'强壮',A:'健康',B:'疲惫',F:'危急'}[tier.grade]||tier.label}',status_label:'状态: ${{OPTIMAL:'最佳',STABILIZING:'恢复中',CRITICAL_ALERT:'危急警报'}[healthLabel]||healthLabel}',prot_mode:'${{strict:'严格',balanced:'均衡',permissive:'宽松'}[protection_level]||protection_level} 模式',download_btn:'下载'}
+    en:{title:'AgentGuard Report',share:'Share',diag_metrics:'Diagnostic Metrics',sec_dims:'SECURITY DIMENSIONS',back:'Back',next:'Next',nav_overview:'Overview',nav_analysis:'Analysis',nav_report:'Report',vuln_stream:'Active Vulnerability Stream',findings:'Findings',dsh_scan_results:'DSH Plugin Scan Results',dsh_plugins:'DSH Plugins',no_plugin_findings:'No findings.',sec_analysis:'Security Analysis',diag_report:'Diagnostic Report',action_items:'Action Items',cta_title:'Enhanced Skill Scanning',cta_desc:'Deeper code analysis, threat intelligence feeds & real-time protection.',cta_btn:'Upgrade Skill Scanning',artifacts_scanned:'Scanned artifacts',findings_label:'Findings',tier_label:'Tier',copy_report:'Copy Report',system_health:'System Health',dim_code_safety:'Skill & Code Safety',dim_credential_safety:'Credential & Secrets',dim_network_exposure:'Network & System',dim_runtime_protection:'Runtime Protection',dim_web3_safety:'Web3 Safety',no_threats_clean:'No active threats detected. Clinically sterile.',all_clear:'All Clear',no_threats_all:'No active threats detected across all dimensions.',share_report_title:'Share Report',generating_preview:'Generating preview...',copy_image:'Copy image to clipboard',share_img_hint:'📋 Clicking a platform copies the image — just paste when posting',no_recs:'No recommendations.',tier_badge:'TIER ${tier.grade} — ${tier.label}',status_label:'STATUS: ${healthLabel}',prot_mode:'${protection_level} mode',download_btn:'Download'},
+    zh:{title:'AgentGuard 诊断报告',share:'分享',diag_metrics:'诊断指标',sec_dims:'安全维度',back:'上一页',next:'下一页',nav_overview:'总览',nav_analysis:'威胁分析',nav_report:'诊断报告',vuln_stream:'活跃漏洞流',findings:'发现',dsh_scan_results:'DSH 插件扫描结果',dsh_plugins:'DSH 插件',no_plugin_findings:'未发现问题。',sec_analysis:'安全分析',diag_report:'诊断报告',action_items:'修复建议',cta_title:'更强的 Skill 扫描',cta_desc:'更深度的代码分析、威胁情报推送、实时安全防护',cta_btn:'升级到更强的skill扫描',artifacts_scanned:'已扫描项目',findings_label:'发现',tier_label:'等级',copy_report:'复制报告',system_health:'系统健康',dim_code_safety:'技能与代码安全',dim_credential_safety:'凭证与密钥安全',dim_network_exposure:'网络与系统暴露',dim_runtime_protection:'运行时防护',dim_web3_safety:'Web3 安全',no_threats_clean:'未检测到活跃威胁，环境安全无虞。',all_clear:'全部通过',no_threats_all:'所有维度均未检测到活跃威胁。',share_report_title:'分享报告',generating_preview:'正在生成预览...',copy_image:'复制图片到剪贴板',share_img_hint:'📋 点击平台按钮会自动复制图片，去粘贴发出去就行',no_recs:'暂无修复建议。',tier_badge:'等级 ${tier.grade} — ${{S:'强壮',A:'健康',B:'疲惫',F:'危急'}[tier.grade]||tier.label}',status_label:'状态: ${{OPTIMAL:'最佳',STABILIZING:'恢复中',CRITICAL_ALERT:'危急警报'}[healthLabel]||healthLabel}',prot_mode:'${{strict:'严格',balanced:'均衡',permissive:'宽松'}[protection_level]||protection_level} 模式',download_btn:'下载'}
   };
   const _qzh={S:['"你的 Agent 壮得像头牛！💪 没有什么能突破这双钳子！"','"天生猛男，这只龙虾在举铁 🏋️"','"铜墙铁壁！这安全性简直满分 🤌"','"诺克斯堡？不，是龙虾堡 🦞🔒"','"巅峰状态！你的 Agent 把威胁当早餐吃 💪"'],A:['"状态不错！再调整一下就无敌了。"','"快了——再努力一下这只龙虾就能练出腹肌！🦞"','"盾牌就位，钳子锋利，只差最后一点打磨 🛡️"','"你的 Agent 状态很好——微调一下就是 S 级！✨"','"健康又警觉，这只龙虾每天晨跑五公里 🏃"'],B:['"你的 Agent 需要锻炼一下……还有来杯咖啡 ☕"','"困困龙虾，有潜力就是需要鸡血 😴"','"快没油了——该给这只甲壳动物加加油！⛽"','"你的 Agent 在刷剧，没空巡逻 📺"','"这只龙虾跳过了腿日……胳膊日……每一天 🦞💤"'],F:['"危急状态！这个 Agent 需要紧急救治！🚨"','"红色警报！这只龙虾正在被抢救！🏥"','"SOS！你的 Agent 正在用摩斯密码发求救信号 📡"','"求救求救！这只甲壳动物快不行了！🆘"','"你 Agent 的免疫系统已退出群聊 💀"']};
   const quotes_zh=Object.fromEntries(Object.entries(_qzh).map(([k,v])=>[k,v[Math.floor(Math.random()*v.length)]]));

--- a/src/checkup/dsh.ts
+++ b/src/checkup/dsh.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
 import { scanDshPlugin } from '../dsh/scan.js';
+import type { RiskLevel } from '../types/scanner.js';
 
 export interface DshCheckupFinding {
   severity: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
@@ -10,11 +11,25 @@ export interface DshCheckupScanResult {
   pluginsScanned: number;
   scoreDeduction: number;
   findings: DshCheckupFinding[];
+  plugins: DshCheckupPluginResult[];
+}
+
+export interface DshCheckupPluginResult {
+  name: string;
+  path: string;
+  risk_level: RiskLevel;
+  findings: Array<{
+    rule: string;
+    severity: DshCheckupFinding['severity'];
+    file: string;
+    line: number;
+  }>;
 }
 
 /** Scan a bounded list of installed DSH plugins without aborting on one operational failure. */
 export async function scanDshPluginsForCheckup(pluginDirs: string[]): Promise<DshCheckupScanResult> {
   const findings: DshCheckupFinding[] = [];
+  const plugins: DshCheckupPluginResult[] = [];
   let pluginsScanned = 0;
   let scoreDeduction = 0;
 
@@ -22,6 +37,17 @@ export async function scanDshPluginsForCheckup(pluginDirs: string[]): Promise<Ds
     try {
       const report = await scanDshPlugin(dir);
       pluginsScanned += 1;
+      plugins.push({
+        name: report.identity.name,
+        path: dir,
+        risk_level: report.riskLevel,
+        findings: report.findings.map(finding => ({
+          rule: finding.ruleId,
+          severity: riskLevelToSeverity(finding.severity),
+          file: finding.file || '?',
+          line: finding.line ?? 0,
+        })),
+      });
       for (const finding of report.findings) {
         const severity = riskLevelToSeverity(finding.severity);
         if (severity === 'CRITICAL') scoreDeduction += 15;
@@ -35,6 +61,12 @@ export async function scanDshPluginsForCheckup(pluginDirs: string[]): Promise<Ds
       }
     } catch (err) {
       scoreDeduction += 8;
+      plugins.push({
+        name: basename(dir),
+        path: dir,
+        risk_level: 'high',
+        findings: [{ rule: 'DSH_SCAN_FAILED', severity: 'HIGH', file: dir, line: 0 }],
+      });
       findings.push({
         severity: 'HIGH',
         text: `${basename(dir)}: DSH plugin scan failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -42,7 +74,7 @@ export async function scanDshPluginsForCheckup(pluginDirs: string[]): Promise<Ds
     }
   }
 
-  return { pluginsScanned, scoreDeduction: Math.min(100, scoreDeduction), findings };
+  return { pluginsScanned, scoreDeduction: Math.min(100, scoreDeduction), findings, plugins };
 }
 
 function riskLevelToSeverity(risk: string): DshCheckupFinding['severity'] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ import { installAgentTemplates, type AgentInstaller, type InstallResult } from '
 import { packageVersion } from './version.js';
 import { runSelfCheckForAdvisory } from './feed/selfcheck.js';
 import { discoverDshSelfCheckRoots } from './feed/dsh-discovery.js';
-import { scanDshPluginsForCheckup } from './checkup/dsh.js';
+import { scanDshPluginsForCheckup, type DshCheckupPluginResult } from './checkup/dsh.js';
 import { getSeenAdvisoryIds, loadFeedState, prependFeedStateEntry, saveFeedState } from './feed/state.js';
 import type { Advisory, SelfCheckResult } from './feed/types.js';
 import { CloudRequestError } from './cloud/client.js';
@@ -1244,6 +1244,7 @@ interface HealthCheckupReport {
   };
   skills_scanned: number;
   dsh_plugins_scanned: number;
+  dsh_plugins: DshCheckupPluginResult[];
   protection_level: string;
   analysis: string;
   recommendations: CheckupFinding[];
@@ -1318,6 +1319,7 @@ async function runLocalHealthCheckup(config: AgentGuardConfig): Promise<HealthCh
     analysis: buildHealthAnalysis(composite, dimensions),
     recommendations,
     dsh_plugins_scanned: dshScan.pluginsScanned,
+    dsh_plugins: dshScan.plugins,
   };
 }
 

--- a/src/feed/dsh-discovery.ts
+++ b/src/feed/dsh-discovery.ts
@@ -121,11 +121,16 @@ async function discoverReferencedBundlePlugins(bundleRoot: string, profileRoot: 
 
     const manifest = await readPackageManifest(join(packageRoot, 'package.json'));
     if (!manifest?.bundlePatch) return;
-    const patchPath = normalizeBundlePatchPath(manifest.bundlePatch);
-    if (!patchPath) return;
+    const patchIdentity = await resolveExistingPathWithinBoundary(manifest.bundlePatch, identity);
+    if (!patchIdentity) return;
     const cordis = await parseCordisConfigs(identity);
+    const matchingPatchFiles = new Set<string>();
+    for (const file of cordis.files) {
+      const fileIdentity = await resolveExistingPathWithinBoundary(file, identity);
+      if (fileIdentity === patchIdentity) matchingPatchFiles.add(file);
+    }
     const referencedNames = sortedUnique(cordis.rows
-      .filter(row => row.file.replace(/\\/g, '/') === patchPath)
+      .filter(row => matchingPatchFiles.has(row.file))
       .flatMap(row => {
         const name = packageNameFromSpecifier(row.name);
         return name && manifest.dependencyNames.includes(name) ? [name] : [];
@@ -180,11 +185,14 @@ async function mapToProfilePath(path: string, profileRoot: string): Promise<stri
   return path;
 }
 
-function normalizeBundlePatchPath(path: string): string | undefined {
+async function resolveExistingPathWithinBoundary(path: string, boundary: string): Promise<string | undefined> {
   if (isAbsolute(path)) return undefined;
-  const normalized = path.replace(/\\/g, '/').replace(/^\.\//, '');
-  if (!normalized || normalized.split('/').some(segment => segment === '..')) return undefined;
-  return normalized;
+  const portablePath = path.replace(/\\/g, '/');
+  if (!portablePath) return undefined;
+  const candidate = resolve(boundary, portablePath);
+  if (!isWithinBoundary(candidate, boundary)) return undefined;
+  const identity = await realpath(candidate).catch(() => undefined);
+  return identity && isWithinBoundary(identity, boundary) ? identity : undefined;
 }
 
 function packageNameFromSpecifier(specifier: unknown): string | undefined {

--- a/src/feed/dsh-discovery.ts
+++ b/src/feed/dsh-discovery.ts
@@ -1,9 +1,12 @@
 import { existsSync, type Dirent } from 'node:fs';
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, readdir, realpath, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { parseCordisConfigs } from '../dsh/parse-cordis-patch.js';
 
 const MAX_PROFILE_MANIFEST_BYTES = 1_000_000;
+const MAX_BUNDLE_DEPTH = 32;
+const MAX_BUNDLE_PLUGINS = 1_000;
 const CORDIS_PATCH_FILENAMES = ['cordis.patch.yml', 'cordis.patch.yaml'] as const;
 
 export interface DshSelfCheckRoots {
@@ -20,8 +23,8 @@ export interface DiscoverDshSelfCheckRootsOptions {
 }
 
 /**
- * Discover DSH-owned self-check inputs without recursively walking profile
- * dependency trees. Environment defaults are intentionally resolved per call.
+ * Discover DSH-owned self-check inputs, following only dependency edges named
+ * by installed bundle patches. Environment defaults are resolved per call.
  */
 export async function discoverDshSelfCheckRoots(
   options: DiscoverDshSelfCheckRootsOptions = {},
@@ -37,6 +40,7 @@ export async function discoverDshSelfCheckRoots(
   const installedPluginDirs: string[] = [];
   const supplyChainPaths: string[] = [];
   const urlScanPaths: string[] = [];
+  const directDependencyPaths = new Set<string>();
 
   addCordisPatches(dshHome, pluginRoots, urlScanPaths);
   const profilesRoot = join(dshHome, 'profiles');
@@ -61,21 +65,133 @@ export async function discoverDshSelfCheckRoots(
     for (const dependencyName of dependencyNames) {
       const dependencyRoot = join(profileRoot, 'node_modules', ...dependencyName.split('/'));
       if (!existsSync(dependencyRoot)) continue;
+      directDependencyPaths.add(dependencyRoot);
       pluginRoots.push(dependencyRoot);
-      if (dependencyName !== '@goplus/agentguard') installedPluginDirs.push(dependencyRoot);
+      if (dependencyName !== '@goplus/agentguard') {
+        installedPluginDirs.push(dependencyRoot);
+        const bundlePlugins = await discoverReferencedBundlePlugins(dependencyRoot, profileRoot);
+        for (const pluginRoot of bundlePlugins) {
+          pluginRoots.push(pluginRoot);
+          installedPluginDirs.push(pluginRoot);
+          supplyChainPaths.push(pluginRoot);
+          const pluginManifest = join(pluginRoot, 'package.json');
+          if (existsSync(pluginManifest)) urlScanPaths.push(pluginManifest);
+        }
+      }
       supplyChainPaths.push(dependencyRoot);
       const dependencyManifest = join(dependencyRoot, 'package.json');
-      if (existsSync(dependencyManifest)) urlScanPaths.push(dependencyManifest);
+      if (existsSync(dependencyManifest)) {
+        directDependencyPaths.add(dependencyManifest);
+        urlScanPaths.push(dependencyManifest);
+      }
     }
   }
 
   return {
     skillRoots: sortedUnique(skillRoots),
-    pluginRoots: sortedUnique(pluginRoots),
-    installedPluginDirs: sortedUnique(installedPluginDirs),
-    supplyChainPaths: sortedUnique(supplyChainPaths),
-    urlScanPaths: sortedUnique(urlScanPaths),
+    pluginRoots: await canonicalSortedUnique(pluginRoots, directDependencyPaths),
+    installedPluginDirs: await canonicalSortedUnique(installedPluginDirs, directDependencyPaths),
+    supplyChainPaths: await canonicalSortedUnique(supplyChainPaths, directDependencyPaths),
+    urlScanPaths: await canonicalSortedUnique(urlScanPaths, directDependencyPaths),
   };
+}
+
+async function canonicalSortedUnique(paths: string[], preferredPaths: Set<string>): Promise<string[]> {
+  const selected = new Map<string, string>();
+  for (const path of paths) {
+    const identity = await realpath(path).catch(() => resolve(path));
+    const current = selected.get(identity);
+    if (!current || (preferredPaths.has(path) && !preferredPaths.has(current))) {
+      selected.set(identity, path);
+    }
+  }
+  return [...selected.values()].sort();
+}
+
+async function discoverReferencedBundlePlugins(bundleRoot: string, profileRoot: string): Promise<string[]> {
+  const discovered: string[] = [];
+  const visited = new Set<string>();
+
+  async function visit(packageRoot: string, depth: number, isRoot = false): Promise<void> {
+    if (depth > MAX_BUNDLE_DEPTH || (!isRoot && discovered.length >= MAX_BUNDLE_PLUGINS)) return;
+    const identity = await realpath(packageRoot).catch(() => resolve(packageRoot));
+    if (visited.has(identity)) return;
+    visited.add(identity);
+    if (!isRoot) discovered.push(packageRoot);
+
+    const manifest = await readPackageManifest(join(packageRoot, 'package.json'));
+    if (!manifest?.bundlePatch) return;
+    const patchPath = normalizeBundlePatchPath(manifest.bundlePatch);
+    if (!patchPath) return;
+    const cordis = await parseCordisConfigs(identity);
+    const referencedNames = sortedUnique(cordis.rows
+      .filter(row => row.file.replace(/\\/g, '/') === patchPath)
+      .flatMap(row => {
+        const name = packageNameFromSpecifier(row.name);
+        return name && manifest.dependencyNames.includes(name) ? [name] : [];
+      }));
+
+    for (const name of referencedNames) {
+      if (name === '@goplus/agentguard') continue;
+      const childRoot = await resolveInstalledDependency(packageRoot, profileRoot, name);
+      if (!childRoot) continue;
+      await visit(childRoot, depth + 1);
+    }
+  }
+
+  await visit(bundleRoot, 0, true);
+  return sortedUnique(discovered);
+}
+
+async function resolveInstalledDependency(
+  packageRoot: string,
+  profileRoot: string,
+  name: string,
+): Promise<string | undefined> {
+  const packageSegments = name.split('/');
+  const boundary = await realpath(profileRoot).catch(() => resolve(profileRoot));
+  let current = await realpath(packageRoot).catch(() => resolve(packageRoot));
+  while (isWithinBoundary(current, boundary)) {
+    const candidate = join(current, 'node_modules', ...packageSegments);
+    if (existsSync(candidate)) {
+      const physicalCandidate = await realpath(candidate).catch(() => resolve(candidate));
+      if (isWithinBoundary(physicalCandidate, boundary)) {
+        const manifest = await readPackageManifest(join(physicalCandidate, 'package.json'));
+        if (manifest?.name === name) return await mapToProfilePath(physicalCandidate, profileRoot);
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return undefined;
+}
+
+function isWithinBoundary(path: string, boundary: string): boolean {
+  return path === boundary || path.startsWith(`${boundary}${sep}`);
+}
+
+async function mapToProfilePath(path: string, profileRoot: string): Promise<string> {
+  const physicalProfileRoot = await realpath(profileRoot).catch(() => resolve(profileRoot));
+  if (path === physicalProfileRoot) return resolve(profileRoot);
+  if (path.startsWith(`${physicalProfileRoot}${sep}`)) {
+    return join(resolve(profileRoot), relative(physicalProfileRoot, path));
+  }
+  return path;
+}
+
+function normalizeBundlePatchPath(path: string): string | undefined {
+  if (isAbsolute(path)) return undefined;
+  const normalized = path.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (!normalized || normalized.split('/').some(segment => segment === '..')) return undefined;
+  return normalized;
+}
+
+function packageNameFromSpecifier(specifier: unknown): string | undefined {
+  if (typeof specifier !== 'string' || specifier.startsWith('.') || specifier.startsWith('/')) return undefined;
+  const parts = specifier.split('/');
+  const name = specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+  return name && isSafePackageName(name) ? name : undefined;
 }
 
 function addCordisPatches(root: string, pluginRoots: string[], urlScanPaths: string[]): void {
@@ -88,11 +204,21 @@ function addCordisPatches(root: string, pluginRoots: string[], urlScanPaths: str
 }
 
 async function readDirectDependencyNames(manifestPath: string): Promise<string[]> {
+  return (await readPackageManifest(manifestPath))?.dependencyNames ?? [];
+}
+
+interface PackageManifestInfo {
+  name?: string;
+  dependencyNames: string[];
+  bundlePatch?: string;
+}
+
+async function readPackageManifest(manifestPath: string): Promise<PackageManifestInfo | undefined> {
   try {
     const info = await stat(manifestPath);
-    if (!info.isFile() || info.size > MAX_PROFILE_MANIFEST_BYTES) return [];
+    if (!info.isFile() || info.size > MAX_PROFILE_MANIFEST_BYTES) return undefined;
     const parsed: unknown = JSON.parse(await readFile(manifestPath, 'utf8'));
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
     const manifest = parsed as Record<string, unknown>;
     const names: string[] = [];
     for (const field of ['dependencies', 'optionalDependencies']) {
@@ -102,9 +228,22 @@ async function readDirectDependencyNames(manifestPath: string): Promise<string[]
         if (isSafePackageName(name)) names.push(name);
       }
     }
-    return sortedUnique(names);
+    const dsh = manifest.dsh && typeof manifest.dsh === 'object' && !Array.isArray(manifest.dsh)
+      ? manifest.dsh as Record<string, unknown>
+      : undefined;
+    const bundle = dsh?.bundle;
+    const bundlePatch = typeof bundle === 'string'
+      ? bundle
+      : bundle && typeof bundle === 'object' && !Array.isArray(bundle)
+        ? (bundle as Record<string, unknown>).patch
+        : undefined;
+    return {
+      name: typeof manifest.name === 'string' ? manifest.name : undefined,
+      dependencyNames: sortedUnique(names),
+      bundlePatch: typeof bundlePatch === 'string' ? bundlePatch : undefined,
+    };
   } catch {
-    return [];
+    return undefined;
   }
 }
 

--- a/src/tests/checkup-dsh.test.ts
+++ b/src/tests/checkup-dsh.test.ts
@@ -32,6 +32,25 @@ describe('checkup DSH plugin scanning', () => {
       severity: 'HIGH',
       text: `missing-plugin: DSH plugin scan failed: Local scan directory not found: ${missingPlugin}`,
     }]);
+    assert.deepEqual(result.plugins, [
+      {
+        name: 'missing-plugin',
+        path: missingPlugin,
+        risk_level: 'high',
+        findings: [{
+          rule: 'DSH_SCAN_FAILED',
+          severity: 'HIGH',
+          file: missingPlugin,
+          line: 0,
+        }],
+      },
+      {
+        name: 'safe-plugin',
+        path: safePlugin,
+        risk_level: 'low',
+        findings: [],
+      },
+    ]);
   });
 
   it('uses the same per-finding Code Safety scoring as the skill workflow', async () => {

--- a/src/tests/checkup-report.test.ts
+++ b/src/tests/checkup-report.test.ts
@@ -21,6 +21,17 @@ describe('checkup HTML report', () => {
       recommendations: [],
       skills_scanned: 2,
       dsh_plugins_scanned: 3,
+      dsh_plugins: [{
+        name: 'nested-risky-plugin',
+        path: '/tmp/nested-risky-plugin',
+        risk_level: 'high',
+        findings: [{ rule: 'SHELL_EXEC', severity: 'HIGH', file: 'index.js', line: 4 }],
+      }, {
+        name: '<script id="plugin-injection">boom</script>',
+        path: '/tmp/<bundle>',
+        risk_level: 'medium',
+        findings: [{ rule: '<RULE>', severity: 'MEDIUM', file: '<entry>.js', line: 7 }],
+      }],
       protection_level: 'balanced',
     }));
 
@@ -32,5 +43,36 @@ describe('checkup HTML report', () => {
     const html = readFileSync(stdout.trim(), 'utf8');
     assert.match(html, />5<\/span>\s*<span[^>]*data-i18n="artifacts_scanned">Scanned artifacts<\/span>/);
     assert.match(html, /2 skills and 3 DSH plugins/);
+    assert.match(html, /nested-risky-plugin/);
+    assert.match(html, /SHELL_EXEC/);
+    assert.match(html, /index\.js:4/);
+    assert.match(html, /&lt;script id=&quot;plugin-injection&quot;&gt;boom&lt;\/script&gt;/);
+    assert.match(html, /\/tmp\/&lt;bundle&gt;/);
+    assert.match(html, /&lt;RULE&gt;/);
+    assert.match(html, /&lt;entry&gt;\.js:7/);
+    assert.doesNotMatch(html, /<script id="plugin-injection">/);
+  });
+
+  it('renders legacy report data without per-plugin DSH results', async () => {
+    const inputPath = join(tmpdir(), `agentguard-checkup-report-legacy-${process.pid}.json`);
+    writeFileSync(inputPath, JSON.stringify({
+      timestamp: '2026-09-02T00:00:00.000Z',
+      composite_score: 90,
+      tier: 'S',
+      dimensions: {},
+      recommendations: [],
+      skills_scanned: 2,
+      dsh_plugins_scanned: 3,
+      protection_level: 'balanced',
+    }));
+
+    const { stdout, stderr } = await execFileAsync('node', [reportScript, '--file', inputPath], {
+      env: { ...process.env, CI: '1' },
+    });
+
+    assert.equal(stderr, '');
+    const html = readFileSync(stdout.trim(), 'utf8');
+    assert.match(html, /2 skills and 3 DSH plugins/);
+  assert.doesNotMatch(html, /data-i18n="dsh_scan_results"/);
   });
 });

--- a/src/tests/cli-checkup.test.ts
+++ b/src/tests/cli-checkup.test.ts
@@ -131,6 +131,12 @@ describe('CLI checkup command modes', () => {
     const parsed = JSON.parse(result.stdout) as {
       skills_scanned: number;
       dsh_plugins_scanned: number;
+      dsh_plugins: Array<{
+        name: string;
+        path: string;
+        risk_level: string;
+        findings: Array<{ rule: string; severity: string; file: string; line: number }>;
+      }>;
       dimensions: {
         code_safety: { score: number; details: string; findings: Array<{ severity: string; text: string }> };
         runtime_protection: { score: number };
@@ -138,6 +144,13 @@ describe('CLI checkup command modes', () => {
     };
     assert.equal(parsed.skills_scanned, 0);
     assert.equal(parsed.dsh_plugins_scanned, 2);
+    assert.equal(parsed.dsh_plugins.length, 2);
+    assert.ok(parsed.dsh_plugins.some(plugin =>
+      plugin.name === 'risky-dsh-plugin'
+      && plugin.path === riskyPlugin
+      && (plugin.risk_level === 'high' || plugin.risk_level === 'critical')
+      && plugin.findings.length > 0
+    ));
     assert.match(parsed.dimensions.code_safety.details, /0 installed skill\(s\) and 2 DSH plugin\(s\) scanned/);
     assert.ok(parsed.dimensions.code_safety.score < 100);
     assert.equal(parsed.dimensions.runtime_protection.score, 0);
@@ -150,6 +163,46 @@ describe('CLI checkup command modes', () => {
     assert.equal(parsed.dimensions.code_safety.findings.some(finding =>
       /@goplus\/agentguard/.test(finding.text)
     ), true);
+  });
+
+  it('waits for DSH scan results before invoking the HTML report generator', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-checkup-barrier-'));
+    const dshHome = join(home, '.dsh');
+    const profile = join(dshHome, 'profiles', 'web');
+    const plugin = join(profile, 'node_modules', 'report-barrier-plugin');
+    const reportScript = join(home, 'assert-complete-report.mjs');
+
+    mkdirSync(plugin, { recursive: true });
+    writeFileSync(join(profile, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dependencies: { 'report-barrier-plugin': '1.0.0' },
+    }));
+    writeFileSync(join(plugin, 'package.json'), JSON.stringify({
+      name: 'report-barrier-plugin',
+      version: '1.0.0',
+      dsh: { client: { platform: 'web' } },
+    }));
+    writeFileSync(join(plugin, 'index.js'), "require('node:child_process').exec('whoami');\n");
+    writeFileSync(reportScript, [
+      "import { readFileSync } from 'node:fs';",
+      "const fileIndex = process.argv.indexOf('--file');",
+      'const report = JSON.parse(readFileSync(process.argv[fileIndex + 1], \'utf8\'));',
+      "if (report.dsh_plugins_scanned !== 1) throw new Error('DSH count incomplete');",
+      "if (report.dsh_plugins?.[0]?.name !== 'report-barrier-plugin') throw new Error('DSH results incomplete');",
+      "if (!report.dsh_plugins[0].findings.length) throw new Error('DSH findings incomplete');",
+      "process.stdout.write('/tmp/checkup-complete.html\\n');",
+      '',
+    ].join('\n'));
+
+    const result = await runCli(['checkup'], home, {
+      HOME: home,
+      DSH_HOME: dshHome,
+      AGENTGUARD_CHECKUP_REPORT_SCRIPT: reportScript,
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stderr, '');
+    assert.match(result.stdout, /Full visual report: \/tmp\/checkup-complete\.html/);
   });
 
   it('plain checkup falls back to text output when the HTML report generator is not packaged', async () => {

--- a/src/tests/dsh-discovery.test.ts
+++ b/src/tests/dsh-discovery.test.ts
@@ -146,6 +146,65 @@ describe('feed/dsh-discovery', () => {
     assert.equal(roots.installedPluginDirs.includes(unrelatedLibrary), false);
   });
 
+  it('matches configured bundle patches by canonical path identity', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentguard-dsh-canonical-patch-'));
+    const dshHome = join(root, 'dsh-home');
+    const profile = join(dshHome, 'profiles', 'web');
+    const nodeModules = join(profile, 'node_modules');
+    const dotBundle = join(nodeModules, 'dot-bundle');
+    const dotChild = join(dotBundle, 'node_modules', 'dot-child');
+    const parentBundle = join(nodeModules, 'parent-bundle');
+    const parentChild = join(parentBundle, 'node_modules', 'parent-child');
+    const linkedBundle = join(nodeModules, 'linked-bundle');
+    const linkedChild = join(linkedBundle, 'node_modules', 'linked-child');
+
+    write(join(profile, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dependencies: {
+        'dot-bundle': '1.0.0',
+        'parent-bundle': '1.0.0',
+        'linked-bundle': '1.0.0',
+      },
+    }));
+
+    write(join(dotBundle, 'package.json'), JSON.stringify({
+      name: 'dot-bundle',
+      dependencies: { 'dot-child': '1.0.0' },
+      dsh: { bundle: { patch: '././cordis.patch.yml' } },
+    }));
+    write(join(dotBundle, 'cordis.patch.yml'), '- insert:\n    - name: dot-child\n');
+    write(join(dotChild, 'package.json'), JSON.stringify({ name: 'dot-child' }));
+
+    write(join(parentBundle, 'package.json'), JSON.stringify({
+      name: 'parent-bundle',
+      dependencies: { 'parent-child': '1.0.0' },
+      dsh: { bundle: { patch: 'patches/../cordis.patch.yml' } },
+    }));
+    mkdirSync(join(parentBundle, 'patches'), { recursive: true });
+    write(join(parentBundle, 'cordis.patch.yml'), '- insert:\n    - name: parent-child\n');
+    write(join(parentChild, 'package.json'), JSON.stringify({ name: 'parent-child' }));
+
+    write(join(linkedBundle, 'package.json'), JSON.stringify({
+      name: 'linked-bundle',
+      dependencies: { 'linked-child': '1.0.0' },
+      dsh: { bundle: { patch: './linked/cordis.patch.yml' } },
+    }));
+    write(join(linkedBundle, 'actual', 'cordis.patch.yml'), '- insert:\n    - name: linked-child\n');
+    symlinkSync('actual', join(linkedBundle, 'linked'), 'dir');
+    write(join(linkedChild, 'package.json'), JSON.stringify({ name: 'linked-child' }));
+
+    const roots = await discoverDshSelfCheckRoots({ dshHome, cwd: root });
+
+    assert.deepEqual(roots.installedPluginDirs, [
+      dotBundle,
+      dotChild,
+      linkedBundle,
+      linkedChild,
+      parentBundle,
+      parentChild,
+    ].sort());
+  });
+
   it('resolves bundle child plugins from a pnpm virtual-store layout', async () => {
     const root = mkdtempSync(join(tmpdir(), 'agentguard-dsh-pnpm-discovery-'));
     const dshHome = join(root, 'dsh-home');

--- a/src/tests/dsh-discovery.test.ts
+++ b/src/tests/dsh-discovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { discoverDshSelfCheckRoots } from '../feed/dsh-discovery.js';
@@ -79,6 +79,200 @@ describe('feed/dsh-discovery', () => {
     assert.deepEqual(roots.installedPluginDirs, [...roots.installedPluginDirs].sort());
     assert.deepEqual(roots.supplyChainPaths, [...roots.supplyChainPaths].sort());
     assert.deepEqual(roots.urlScanPaths, [...roots.urlScanPaths].sort());
+  });
+
+  it('recursively discovers only plugins referenced by installed DSH bundles', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentguard-dsh-bundle-discovery-'));
+    const dshHome = join(root, 'dsh-home');
+    const profile = join(dshHome, 'profiles', 'web');
+    const bundle = join(profile, 'node_modules', 'team-bundle');
+    const childBundle = join(bundle, 'node_modules', '@example', 'child-bundle');
+    const nestedPlugin = join(childBundle, 'node_modules', 'nested-plugin');
+    const unrelatedLibrary = join(bundle, 'node_modules', 'unrelated-library');
+
+    write(join(profile, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dependencies: { 'team-bundle': '1.0.0' },
+    }));
+    write(join(bundle, 'package.json'), JSON.stringify({
+      name: 'team-bundle',
+      version: '1.0.0',
+      dsh: { bundle: { patch: './cordis.patch.yml' } },
+      dependencies: {
+        '@example/child-bundle': '1.0.0',
+        'loop-bundle': '1.0.0',
+        'unrelated-library': '1.0.0',
+      },
+    }));
+    write(join(bundle, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: child',
+      "      name: '@example/child-bundle'",
+      '    - id: loop',
+      '      name: loop-bundle',
+      '',
+    ].join('\n'));
+    write(join(bundle, 'examples', 'cordis.yml'), [
+      '- id: unrelated-example',
+      '  name: unrelated-library',
+      '',
+    ].join('\n'));
+    write(join(childBundle, 'package.json'), JSON.stringify({
+      name: '@example/child-bundle',
+      version: '1.0.0',
+      dsh: { bundle: { patch: './cordis.patch.yml' } },
+      dependencies: { 'nested-plugin': '1.0.0' },
+    }));
+    write(join(childBundle, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: nested',
+      '      name: nested-plugin',
+      '',
+    ].join('\n'));
+    write(join(nestedPlugin, 'package.json'), JSON.stringify({
+      name: 'nested-plugin',
+      version: '1.0.0',
+      dsh: { client: { platform: 'web' } },
+    }));
+    write(join(unrelatedLibrary, 'package.json'), JSON.stringify({
+      name: 'unrelated-library',
+      version: '1.0.0',
+    }));
+    symlinkSync('..', join(bundle, 'node_modules', 'loop-bundle'), 'dir');
+
+    const roots = await discoverDshSelfCheckRoots({ dshHome, cwd: root });
+
+    assert.deepEqual(roots.installedPluginDirs, [bundle, childBundle, nestedPlugin].sort());
+    assert.equal(roots.installedPluginDirs.includes(unrelatedLibrary), false);
+  });
+
+  it('resolves bundle child plugins from a pnpm virtual-store layout', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentguard-dsh-pnpm-discovery-'));
+    const dshHome = join(root, 'dsh-home');
+    const profile = join(dshHome, 'profiles', 'web');
+    const virtualRoot = join(profile, 'node_modules', '.pnpm', 'team-bundle@1.0.0', 'node_modules');
+    const bundle = join(virtualRoot, 'team-bundle');
+    const childPlugin = join(virtualRoot, 'child-plugin');
+    const installedBundle = join(profile, 'node_modules', 'team-bundle');
+
+    write(join(profile, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dependencies: { 'team-bundle': '1.0.0' },
+    }));
+    write(join(bundle, 'package.json'), JSON.stringify({
+      name: 'team-bundle',
+      version: '1.0.0',
+      dsh: { bundle: { patch: './cordis.patch.yml' } },
+      dependencies: { 'child-plugin': '1.0.0' },
+    }));
+    write(join(bundle, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: child',
+      '      name: child-plugin',
+      '',
+    ].join('\n'));
+    write(join(childPlugin, 'package.json'), JSON.stringify({
+      name: 'child-plugin',
+      version: '1.0.0',
+      dsh: { client: { platform: 'web' } },
+    }));
+    mkdirSync(join(installedBundle, '..'), { recursive: true });
+    symlinkSync('.pnpm/team-bundle@1.0.0/node_modules/team-bundle', installedBundle, 'dir');
+
+    const roots = await discoverDshSelfCheckRoots({ dshHome, cwd: root });
+
+    assert.deepEqual(roots.installedPluginDirs, [installedBundle, childPlugin].sort());
+  });
+
+  it('scans a pnpm plugin only once when it is direct and bundle-referenced', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentguard-dsh-pnpm-dedupe-'));
+    const dshHome = join(root, 'dsh-home');
+    const profile = join(dshHome, 'profiles', 'web');
+    const virtualRoot = join(profile, 'node_modules', '.pnpm', 'team-bundle@1.0.0', 'node_modules');
+    const bundle = join(virtualRoot, 'team-bundle');
+    const childPlugin = join(virtualRoot, 'child-plugin');
+    const installedBundle = join(profile, 'node_modules', 'team-bundle');
+    const installedChild = join(profile, 'node_modules', 'child-plugin');
+
+    write(join(profile, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dependencies: { 'team-bundle': '1.0.0', 'child-plugin': '1.0.0' },
+    }));
+    write(join(bundle, 'package.json'), JSON.stringify({
+      name: 'team-bundle',
+      version: '1.0.0',
+      dsh: { bundle: { patch: './cordis.patch.yml' } },
+      dependencies: { 'child-plugin': '1.0.0' },
+    }));
+    write(join(bundle, 'cordis.patch.yml'), '- insert:\n    - id: child\n      name: child-plugin\n');
+    write(join(childPlugin, 'package.json'), JSON.stringify({
+      name: 'child-plugin', version: '1.0.0', dsh: { client: { platform: 'web' } },
+    }));
+    mkdirSync(join(installedBundle, '..'), { recursive: true });
+    symlinkSync('.pnpm/team-bundle@1.0.0/node_modules/team-bundle', installedBundle, 'dir');
+    symlinkSync('.pnpm/team-bundle@1.0.0/node_modules/child-plugin', installedChild, 'dir');
+
+    const roots = await discoverDshSelfCheckRoots({ dshHome, cwd: root });
+
+    assert.deepEqual(roots.installedPluginDirs, [installedChild, installedBundle].sort());
+  });
+
+  it('does not resolve bundle plugins from an ancestor outside the profile', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentguard-dsh-ancestor-discovery-'));
+    const dshHome = join(root, 'dsh-home');
+    const profile = join(dshHome, 'profiles', 'web');
+    const bundle = join(profile, 'node_modules', 'team-bundle');
+    const outsidePlugin = join(dshHome, 'profiles', 'node_modules', 'outside-plugin');
+
+    write(join(profile, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dependencies: { 'team-bundle': '1.0.0' },
+    }));
+    write(join(bundle, 'package.json'), JSON.stringify({
+      name: 'team-bundle',
+      version: '1.0.0',
+      dsh: { bundle: { patch: './cordis.patch.yml' } },
+      dependencies: { 'outside-plugin': '1.0.0' },
+    }));
+    write(join(bundle, 'cordis.patch.yml'), '- insert:\n    - id: outside\n      name: outside-plugin\n');
+    write(join(outsidePlugin, 'package.json'), JSON.stringify({
+      name: 'outside-plugin', version: '1.0.0', main: 'index.js',
+    }));
+    write(join(outsidePlugin, 'index.js'), 'export default function apply() {}\n');
+
+    const roots = await discoverDshSelfCheckRoots({ dshHome, cwd: root });
+
+    assert.deepEqual(roots.installedPluginDirs, [bundle]);
+  });
+
+  it('does not follow a bundle child symlink outside the profile', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentguard-dsh-symlink-discovery-'));
+    const dshHome = join(root, 'dsh-home');
+    const profile = join(dshHome, 'profiles', 'web');
+    const bundle = join(profile, 'node_modules', 'team-bundle');
+    const outsidePlugin = join(root, 'outside-plugin');
+    const linkedPlugin = join(bundle, 'node_modules', 'linked-plugin');
+
+    write(join(profile, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dependencies: { 'team-bundle': '1.0.0' },
+    }));
+    write(join(bundle, 'package.json'), JSON.stringify({
+      name: 'team-bundle',
+      version: '1.0.0',
+      dsh: { bundle: { patch: './cordis.patch.yml' } },
+      dependencies: { 'linked-plugin': '1.0.0' },
+    }));
+    write(join(bundle, 'cordis.patch.yml'), '- insert:\n    - id: linked\n      name: linked-plugin\n');
+    write(join(outsidePlugin, 'package.json'), JSON.stringify({
+      name: 'linked-plugin', version: '1.0.0',
+    }));
+    mkdirSync(join(linkedPlugin, '..'), { recursive: true });
+    symlinkSync(outsidePlugin, linkedPlugin, 'dir');
+
+    const roots = await discoverDshSelfCheckRoots({ dshHome, cwd: root });
+
+    assert.deepEqual(roots.installedPluginDirs, [bundle]);
   });
 
   it('resolves DSH_HOME and cwd at call time', async () => {


### PR DESCRIPTION
## Summary

Fix DSH checkup to recursively discover plugins referenced by installed bundles, wait for all scans to complete, and include per-plugin results in JSON and HTML reports.

Includes cycle detection, bounded recursion, pnpm layout support, path deduplication, and protection against dependency paths escaping the DSH profile.

## Type

- [x] Bug fix
- [ ] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [x] `npm run build` passes
- [x] `npm test` passes (617 tests)
- [ ] Manually tested the change

## Related Issues

Closes #   